### PR TITLE
camelize relationship names as well

### DIFF
--- a/src/json-api-parser.js
+++ b/src/json-api-parser.js
@@ -18,7 +18,7 @@ class JsonApiParser {
   parse(resource) {
     let result = {};
     if (resource.attributes) {
-      _.extend(result, this._parseWithNames(resource.attributes));
+      _.extend(result, resource.attributes);
     }
     result.id = resource.id;
     result._type = resource.type;
@@ -28,7 +28,8 @@ class JsonApiParser {
     if (resource.relationships) {
       result.relationships = resource.relationships;
     }
-    return result;
+
+    return this._parseWithNames(result);
   }
 
   /**

--- a/tests/test-internal-model.js
+++ b/tests/test-internal-model.js
@@ -9,13 +9,13 @@ let createStore = function () {
   let store = new Store(adapter);
   store.register('user', {
     relationships: {
-      'so': 'user',
-      'bff': 'user',
-      'friends': 'user',
-      'mother': 'user',
-      'siblings': 'user',
-      'all-together-now': 'user',
-      'enemy': 'two-face'
+      so: 'user',
+      bff: 'user',
+      friends: 'user',
+      mother: 'user',
+      siblings: 'user',
+      allTogetherNow: 'user',
+      enemy: 'two-face'
     }
   });
   return store;
@@ -125,7 +125,7 @@ let userWithRelationships = {
           related: '/user/1/siblings'
         }
       },
-      'all-together-now': {
+      allTogetherNow: {
         data: [
           {id: 2, type: 'user'},
           {id: 3, type: 'user'},
@@ -259,7 +259,7 @@ describe('InternalModel', function () {
 
     it('hasMany returns a partial collection models from the cache, and hits the network for remaining models', function () {
       this.server.respondWith('GET', '/user/1/all-together-now', JSON.stringify(allTogetherNow));
-      let relationship = this.resource.getRelated('all-together-now');
+      let relationship = this.resource.getRelated('allTogetherNow');
       assert.equal(relationship.length, 2);
       return relationship
         .then(() => assert.equal(relationship.length, 5));
@@ -267,7 +267,7 @@ describe('InternalModel', function () {
 
     it('hasMany partial collection will resolve to a collection of models', function () {
       this.server.respondWith('GET', '/user/1/all-together-now', JSON.stringify(allTogetherNow));
-      let relationship = this.resource.getRelated('all-together-now');
+      let relationship = this.resource.getRelated('allTogetherNow');
       assert.equal(relationship.length, 2);
       return relationship
         .then((rest) => assert.instanceOf(rest, Collection));


### PR DESCRIPTION
There was an issue in main app. When model was fetched/updated several times we got relationships in camelCase, but we expected them in dash-case. Using cacmelCase everywhere looks like the cleanest solution.