### PR TITLE
Trigger 'sync' event when ModeProxy content is set

### DIFF
--- a/src/model-proxy.js
+++ b/src/model-proxy.js
@@ -22,6 +22,7 @@ class ModelProxy {
     if (oldContent !== val) {
       this._content = val;
       this._migrateEvents(oldContent);
+      if (this._content) this._content.trigger('sync');
     }
   }
 


### PR DESCRIPTION
We've experienced problems with models returned from the store after first fetching them. Typically we bind to the 'sync' event to re-render our views, but the ModelProxy content is swapped _after_ the model 'sync' event is triggered and the view never sees the event.

This code needs tests (will handle on Monday) and I am up for a discussion about the semantics of which event should be triggered, but I think 'sync' is correct.