### PR TITLE
added meta to collection

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -54,7 +54,7 @@ class Store {
    * @param {Function} resource - a JSON API document
    */
   push(resource) {
-    let {data, included} = resource;
+    let {data, included, meta} = resource;
 
     if (!resource.hasOwnProperty('data')) {
       throw new Error('Expected the resource pushed to include a top level property `data`');
@@ -64,15 +64,19 @@ class Store {
       included.forEach(model => this._pushInternalModel(model));
     }
 
+    let result = null;
+
     if (_.isArray(data)) {
-      return new Collection(data.map(model => this._pushInternalModel(model)));
+      result = new Collection(data.map(model => this._pushInternalModel(model)));
+    } else if (data) {
+      result = this._pushInternalModel(data);
     }
 
-    if (data == null) {
-      return null;
+    if (meta) {
+      result.meta = meta;
     }
 
-    return this._pushInternalModel(data);
+    return result;
   }
 
   _pushInternalModel(data) {


### PR DESCRIPTION
JSON API spec says that response may contain `meta` property.

We can use if for catalog. Right now we return search_block, search_block_css, search_string fields in search endpoint response. (see screenshot below)

![image](https://user-images.githubusercontent.com/4644052/35809318-4ff6c4bc-0a99-11e8-8f88-cfd51fb6fd60.png)

We want to use JSON API for this endpoint and `meta` looks like the right place to put this data.

We can also use it to return pagination data (page, page_size, from, to, etc.). Response will look like this:
```
{
  "data": [...],
  "meta": {
    "search-string": "my search",
    "search-block-css": "...",
    "search-block": "...",
    "page": 2,
    "page-size": 20,
    "from": 21,
    "to": 40,
    "total": 264
  },
  "links": {...}
}
````

I put meta to model or collection root so you can do:
```
const model = store.get('model', modelId);
console.log(model.meta) // meta from model response

// or

const collection = store.get('model');
console.log(collection.meta) // meta from collection response
```
