### PR TITLE
allow relationship to have no data field

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -245,12 +245,14 @@ class Store {
    * @private
    */
   getHasMany (owner, link, all, query) {
-    let models = this.peekMany(all)
-    if (!models.content._incomplete) {
-      return models
-    } else {
-      return this.fetchHasMany(owner, models, link, query)
+    let models
+    if (all != null) {
+      models = this.peekMany(all)
+      if (!models.content._incomplete) {
+        return models
+      }
     }
+    return this.fetchHasMany(owner, models, link, query)
   }
 
   /**


### PR DESCRIPTION
Allow relationship to have no data field. This is made for backend performance.