### PR TITLE
added new relationship type 'unknown'

### DIFF
--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -33,8 +33,10 @@ let InternalModel = Model.extend({
     let relationship = this.getRelationship(relationName)
     if (_.isArray(relationship.data)) {
       return 'has-many'
-    } else {
+    } else if (relationship.data) {
       return 'belongs-to'
+    } else {
+      return 'unknown'
     }
   },
 
@@ -69,7 +71,9 @@ let InternalModel = Model.extend({
     let link = this.getRelationshipLink(relationName)
     let relType = this.getRelationshipType(relationName)
 
-    if (relType === 'has-many') {
+    if (relType === 'unknown') {
+      return this.fetchRelated(relationName, query)
+    } else if (relType === 'has-many') {
       let data = this.getRelationship(relationName).data
       return this.store.getHasMany(this, link, data, query)
     } else {
@@ -82,7 +86,9 @@ let InternalModel = Model.extend({
     let link = this.getRelationshipLink(relationName)
     let relType = this.getRelationshipType(relationName)
 
-    if (relType === 'has-many') {
+    if (relType === 'unknown') {
+      return this.store.fetchUnknown(link, query)
+    } else if (relType === 'has-many') {
       return this.store.fetchHasMany(this, null, link, query)
     } else {
       let {type, id} = this.getRelationship(relationName).data

--- a/src/store.js
+++ b/src/store.js
@@ -245,14 +245,12 @@ class Store {
    * @private
    */
   getHasMany (owner, link, all, query) {
-    let models
-    if (all != null) {
-      models = this.peekMany(all)
-      if (!models.content._incomplete) {
-        return models
-      }
+    let models = this.peekMany(all)
+    if (!models.content._incomplete) {
+      return models
+    } else {
+      return this.fetchHasMany(owner, models, link, query)
     }
-    return this.fetchHasMany(owner, models, link, query)
   }
 
   /**
@@ -267,6 +265,13 @@ class Store {
     models.promise = promise
 
     return result
+  }
+
+  /**
+   * @private
+   */
+  fetchUnknown (link, query) {
+    return this._fetch(link, query)
   }
 
   create (resource) {


### PR DESCRIPTION
Fixed ability to fetch relationships without data

Relationship object can be without data field. Here's what json api spec tells about it here: http://jsonapi.org/format/#document-resource-object-relationships
<img width="694" alt="2018-10-12 9 28 18" src="https://user-images.githubusercontent.com/4644052/46881711-31c3ba00-ce01-11e8-94bb-6cbc74f51e44.png">

 It says 'at least one of the following fields'