### PR TITLE
Provide instructions about working on `backbone.store` locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "scripts": {
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",


### PR DESCRIPTION
And rename `prepack` to `build` to better follow community conventions.