### PR TITLE
Ensure that `getRelated` always returns `Boolean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,94 @@
 
 Backbone Store is a library for managing and caching data in Backbone applications.
 
+## Contributing to Backbone Store
+
+If you're using `@groveco/backbone.store` in your own project:
+
+1. Clone this repo locally, e.g.
+  ```sh
+  $> git clone https://github.com/groveco/backbone.store ~/Projects/backbone.store && cd $_
+  Cloning https://github.com/groveco/backbone.store into ~/Projects/backbone.store
+  . . .
+  cd ~/Projects/backbone.store
+  $> pwd
+  ~/Projects/backbone.store
+  ```
+2. Link your work-tree as the globally installed package:
+  ```sh
+  $> pwd
+  ~/Projects/backbone.store
+  $> npm link
+  npm install...
+  linking @groveco/backbone.store
+  $> npm ls --global --depth=0
+  /path/to/global/node_modules
+  ├── @groveco/backbone.store@X.Y.Z -> ~/Projects/backbone.store
+  ├── nodemon@1.18.9
+  └── npm@6.1.0
+  ```
+3. Link the globally linked version of `backbone.store` in the work-tree of the project that is consuming `backbone.store`:
+  ```sh
+  $> pwd
+  ~/Projects/backbone.store
+  $> pushd ../other-project ## e.g. `groveco/grove`
+  ~/Projects/other-project  ~/Projects/backbone.store
+  $> npm link @groveco/backbone.store
+  ~/other-project/node_modules/@groveco/backbone.store -> /path/to/global/node_modules/@groveco/backbone.store -> ~/Projects/backbone.store
+  ```
+4. Switch back to your local clone of `groveco/backbone.store` and get to work!
+  ```sh
+  $> pwd
+  ~/Projects/other-project
+  $> popd
+  ~/Projects/backbone.store
+  ```
+5. Run `npm run build` to recompile the library:
+  ```sh
+  $> pwd
+  ~/Projects/backbone.store
+  $> npm run build
+
+  > @groveco/backbone.store@0.2.3 build ~/Projects/backbone.store
+  > babel src --out-dir dist
+
+  src/camelcase-dash.js -> dist/camelcase-dash.js
+  src/collection-proxy.js -> dist/collection-proxy.js
+  src/http-adapter.js -> dist/http-adapter.js
+  src/index.js -> dist/index.js
+  src/internal-model.js -> dist/internal-model.js
+  src/json-api-parser.js -> dist/json-api-parser.js
+  src/model-proxy.js -> dist/model-proxy.js
+  src/repository-collection.js -> dist/repository-collection.js
+  src/repository.js -> dist/repository.js
+  src/store.js -> dist/store.js
+
+  $> tree dist/
+  dist
+  ├── camelcase-dash.js
+  ├── collection-proxy.js
+  ├── http-adapter.js
+  ├── index.js
+  ├── internal-model.js
+  ├── json-api-parser.js
+  ├── model-proxy.js
+  ├── repository-collection.js
+  ├── repository.js
+  └── store.js
+
+  0 directories, 10 files
+  ```
+6. Rebuild `other-project` to pick up the changes to `backbone.store`
+
+> **Bonus:** Run `npm run build:watch` to rebuild when any file updates. If
+> your `other-project` build is _also_ watching for filesystem changes, the
+> rebuild in `backbone.store` will trigger it as well.
+
+> **Caveat:** Running `npm install` in `other-project` will destroy the link
+> that you made in Step 3 above, so if your build process runs `npm install`,
+> you'll have to rerun `npm link` per Step 3 after the build starts... or pass
+> `--link` to `npm install`.
+
 ## Using Backbone Store
 
 ### Defining models
@@ -78,5 +166,5 @@ let repo = new BackboneStore.Repository(BlogModel, adapter);
 let store = BackboneStore.Store.instance();
 
 // model name is the same as in defining models
-store.register('blog', repo); 
+store.register('blog', repo);
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "backbone": "^1.3.3",
     "clone": "^2.1.0",
     "jquery": "^2.2.4",
-    "underscore": "^1.8.3"
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "scripts": {
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "scripts": {
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.3.0",
+  "version": "0.3.0-1",
   "scripts": {
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "main": "dist/index.js",
   "version": "0.2.3",
   "scripts": {
-    "prepack": "babel src --out-dir dist",
+    "prepack": "npm run build",
+    "build": "babel src --out-dir dist",
+    "build:watch": "babel --watch src --out-dir dist",
     "test": "jest ./tests",
     "lint": "eslint ./src/index.js"
   },

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -96,33 +96,26 @@ export default Model.extend({
   },
 
   getRelated (relationName, query) {
-    let link = this.getRelationshipLink(relationName)
-    let relType = this.getRelationshipType(relationName)
+    const link = this.getRelationshipLink(relationName)
 
-    if (relType === 'unknown') {
-      return this.fetchRelated(relationName, query)
-    } else if (relType === 'has-many') {
-      let data = this.getRelationship(relationName).data
-      return this.store.getHasMany(this, link, data, query)
-    } else {
-      let {type, id} = this.getRelationship(relationName).data
-      return this.store.getBelongsTo(this, link, type, id, query)
-    }
+    const related = _.result(this.getRelationship(relationName), 'data')
+
+    if (!related) return this.fetchRelated(relationName, query)
+
+    return _.isArray(related)
+      ? this.store.getHasMany(this, link, related, query)
+      : this.store.getBelongsTo(this, link, related.type, related.id, query)
   },
 
   fetchRelated (relationName, query) {
     let link = this.getRelationshipLink(relationName)
-    let relType = this.getRelationshipType(relationName)
 
-    if (relType === 'unknown') {
-      return this.store.fetchUnknown(link, query)
-    } else if (relType === 'has-many') {
-      return this.store.fetchHasMany(this, null, link, query)
-    } else {
-      let {type, id} = this.getRelationship(relationName).data
-      return this.store.fetchBelongsTo(this, link, type, id, query)
-    }
+    const related = _.result(this.getRelationship(relationName), 'data')
+
+    if (!related) return this.store.fetchUnknown(link, query)
+
+    return (_.isArray(related))
+      ? this.store.fetchHasMany(this, null, link, query)
+      : this.store.fetchBelongsTo(this, link, related.type, related.id, query)
   },
-
 })
-

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -59,16 +59,21 @@ export default Model.extend({
     return this.relationships && this.relationships[relationName]
   },
 
-  getRelationship (relationName) {
+  getRelationship (relationName, strict = true) {
     let modelName = this._getRelationForName(relationName)
-    if (modelName == null) {
-      throw new Error('Relation for "' + relationName + '" is not defined on the model.')
+
+    if (modelName == null && strict) {
+      if (strict) throw new Error('Relation for "' + relationName + '" is not defined on the model.')
+
+      return null
     }
 
     let relationship = _.result(this.get('relationships'), relationName)
 
     if (relationship == null) {
-      throw new Error('There is no relationship "' + relationName + '" in the resource.')
+      if (strict) throw new Error('There is no relationship "' + relationName + '" in the resource.')
+
+      return null
     }
 
     return relationship
@@ -85,7 +90,7 @@ export default Model.extend({
   },
 
   hasRelated (relationName) {
-    const relationship = this.getRelationship(relationName)
+    const relationship = this.getRelationship(relationName, false)
 
     return !!_.result(relationship, ['data', 'id'])
   },

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -26,8 +26,8 @@ export default Model.extend({
   },
 
   toJSON () {
-    let attributes = _.clone(this.attributes)
-    let computed = _.mapObject(this.computed, (cp) => cp.call(this))
+    const attributes = _.clone(this.attributes)
+    const computed = _.mapObject(this.computed, (cp) => cp.call(this))
     return _.extend(attributes, computed)
   },
 
@@ -46,7 +46,7 @@ export default Model.extend({
   },
 
   getRelationshipLink (relationName) {
-    let link = _.result(this.getRelationship(relationName), ['links', 'related'])
+    const link = _.result(this.getRelationship(relationName), ['links', 'related'])
 
     if (link == null) {
       throw new Error(`link for, "${relationName}", is undefined for ${this.get('_type')}-${this.id}`)
@@ -60,7 +60,7 @@ export default Model.extend({
   },
 
   getRelationship (relationName, strict = true) {
-    let modelName = this._getRelationForName(relationName)
+    const modelName = this._getRelationForName(relationName)
 
     if (modelName == null && strict) {
       if (strict) throw new Error('Relation for "' + relationName + '" is not defined on the model.')
@@ -68,7 +68,7 @@ export default Model.extend({
       return null
     }
 
-    let relationship = _.result(this.get('relationships'), relationName)
+    const relationship = _.result(this.get('relationships'), relationName)
 
     if (relationship == null) {
       if (strict) throw new Error('There is no relationship "' + relationName + '" in the resource.')
@@ -80,7 +80,7 @@ export default Model.extend({
   },
 
   getRelationshipType (relationName) {
-    let relationship = _.result(this.getRelationship(relationName), 'data')
+    const relationship = _.result(this.getRelationship(relationName), 'data')
 
     if (_.isArray(relationship)) return 'has-many'
 
@@ -108,7 +108,7 @@ export default Model.extend({
   },
 
   fetchRelated (relationName, query) {
-    let link = this.getRelationshipLink(relationName)
+    const link = this.getRelationshipLink(relationName)
 
     const related = _.result(this.getRelationship(relationName), 'data')
 

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -31,12 +31,18 @@ export default Model.extend({
     return _.extend(attributes, computed)
   },
 
+  /**
+   * {Backbone.Model} does not provide "computed" properties.
+   *
+   * @param {string} attr name
+   * @return {mixed|undefined} via {attributes[attr]} or {computed[attr]}
+   */
   get (attr) {
-    if (this.attributes.hasOwnProperty(attr)) {
-      return this.attributes[attr]
-    } else if (this.computed.hasOwnProperty(attr)) {
-      return this.computed[attr].call(this)
-    }
+    if (this.attributes.hasOwnProperty(attr)) return this.attributes[attr]
+
+    if (this.computed.hasOwnProperty(attr)) return this.computed[attr].call(this)
+
+    return undefined
   },
 
   getRelationshipType (relationName) {

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -46,10 +46,12 @@ export default Model.extend({
   },
 
   getRelationshipLink (relationName) {
-    let link = this.getRelationship(relationName).links.related
+    let link = _.result(this.getRelationship(relationName), ['links', 'related'])
+
     if (link == null) {
       throw new Error(`link for, "${relationName}", is undefined for ${this.get('_type')}-${this.id}`)
     }
+
     return link
   },
 
@@ -63,7 +65,8 @@ export default Model.extend({
       throw new Error('Relation for "' + relationName + '" is not defined on the model.')
     }
 
-    let relationship = this.get('relationships') && this.get('relationships')[relationName]
+    let relationship = _.result(this.get('relationships'), relationName)
+
     if (relationship == null) {
       throw new Error('There is no relationship "' + relationName + '" in the resource.')
     }
@@ -83,7 +86,8 @@ export default Model.extend({
 
   hasRelated (relationName) {
     const relationship = this.getRelationship(relationName)
-    return !!(relationship && relationship.data && relationship.data.id)
+
+    return !!_.result(relationship, ['data', 'id'])
   },
 
   getRelated (relationName, query) {

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -1,17 +1,27 @@
 import _ from 'underscore'
-import {Model} from 'backbone'
+import { Model } from 'backbone'
 
-let InternalModel = Model.extend({
+function attributesWithDefaults(attributes, defaults) {
+  return _.defaults(_.extend({}, defaults, attributes), defaults)
+}
+
+export default Model.extend({
   constructor: function (attributes) {
-    let defaults = _.result(this, 'defaults')
-    attributes || (attributes = {})
+    _.defaults(this, {
+      defaults: { },
+      attributes: { },
+      computed: { },
+      changed: { },
+    })
 
-    this.cid = _.uniqueId(this.cidPrefix)
-    this.attributes = {}
-    if (this.computed == null) this.computed = {}
-    attributes = _.defaults(_.extend({}, defaults, attributes), defaults)
-    this.set(attributes)
-    this.changed = {}
+    _.extend(this, {
+      cid: _.uniqueId(this.cidPrefix)
+    })
+
+    const defaults = _.result(this, 'defaults')
+
+    this.set(attributesWithDefaults(attributes, defaults))
+
     this.initialize.apply(this, arguments)
   },
 
@@ -101,4 +111,3 @@ let InternalModel = Model.extend({
   }
 })
 
-export default InternalModel

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -45,23 +45,16 @@ export default Model.extend({
     return undefined
   },
 
-  getRelationshipType (relationName) {
-    let relationship = this.getRelationship(relationName)
-    if (_.isArray(relationship.data)) {
-      return 'has-many'
-    } else if (relationship.data) {
-      return 'belongs-to'
-    } else {
-      return 'unknown'
-    }
-  },
-
   getRelationshipLink (relationName) {
     let link = this.getRelationship(relationName).links.related
     if (link == null) {
       throw new Error(`link for, "${relationName}", is undefined for ${this.get('_type')}-${this.id}`)
     }
     return link
+  },
+
+  _getRelationForName (relationName) {
+    return this.relationships && this.relationships[relationName]
   },
 
   getRelationship (relationName) {
@@ -76,6 +69,16 @@ export default Model.extend({
     }
 
     return relationship
+  },
+
+  getRelationshipType (relationName) {
+    let relationship = _.result(this.getRelationship(relationName), 'data')
+
+    if (_.isArray(relationship)) return 'has-many'
+
+    if (relationship) return 'belongs-to'
+
+    return null
   },
 
   hasRelated (relationName) {
@@ -112,8 +115,5 @@ export default Model.extend({
     }
   },
 
-  _getRelationForName (relationName) {
-    return this.relationships && this.relationships[relationName]
-  }
 })
 

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -1,7 +1,7 @@
 import _ from 'underscore'
 import { Model } from 'backbone'
 
-function attributesWithDefaults(attributes, defaults) {
+function attributesWithDefaults (attributes, defaults) {
   return _.defaults(_.extend({}, defaults, attributes), defaults)
 }
 
@@ -11,7 +11,7 @@ export default Model.extend({
       defaults: { },
       attributes: { },
       computed: { },
-      changed: { },
+      changed: { }
     })
 
     _.extend(this, {
@@ -117,5 +117,5 @@ export default Model.extend({
     return (_.isArray(related))
       ? this.store.fetchHasMany(this, null, link, query)
       : this.store.fetchBelongsTo(this, link, related.type, related.id, query)
-  },
+  }
 })

--- a/tests/internal-model.spec.js
+++ b/tests/internal-model.spec.js
@@ -203,19 +203,22 @@ describe('InternalModel', function () {
     })
   })
 
-  describe('hasRelated', function () {
+  describe('hasRelated', () => {
     let resource
-    beforeEach(function () {
-      let store = createStore()
-      resource = store.push(userWithRelationships)
+    beforeEach(() => {
+      resource = createStore().push(userWithRelationships)
     })
 
-    it('returns true if the relationship is exists', function () {
+    it('returns true if the relationship exists', () => {
       expect(resource.hasRelated('bff')).toBeTruthy()
     })
 
-    it('returns false if the relationship is exists', function () {
+    it('returns false if the relationship does NOT exist', () => {
       expect(resource.hasRelated('so')).toBeFalsy()
+    })
+
+    it('returns false if the relationship is invalid', () => {
+      expect(resource.hasRelated('nada')).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
The only change that I'm skeptical of is the one in `getRelated` and `fetchRelated`, which don't currently have tests for the error case: requesting a relationship that doesn't exist.

### Todos

- [x] Replace `let` with `const` to protect against accidental mutation
- [x] Bump `underscore@^1.9` to match `groveco/grove`