### PR TITLE
Exclude `branches` from the `publish` step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,5 +109,8 @@ workflows:
             - lint
             - test
           filters:
+            branches:
+              only: -none-
+              ignore: /^.*$/
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /^v[0-9]+(\.[0-9]+){2}$/


### PR DESCRIPTION
Whenever we push a branch to `backbone.store`, Circle CI attempts to run the `publish` job, which runs `npm publish` on the code _in the branch_. That wasn't the intended effect of the job spec: to `npm publish` _tagged_ versions. 

According to [the `spec` specification for `.circleci/config.yaml`](https://circleci.com/docs/2.0/configuration-reference/#branches-2), branches have to be explicitly _excluded_ from a job step:
> - If neither `only` nor `ignore` are specified then all branches will run the job.

The `tags` filter could be more restrictive, too, since we don't need to publish RC versions, e.g. `0.3.0-0`.

This proposed change will require us to tag `master` when we're ready to publish a version. Currently, _any pushed branch_ requires a version bump or CI will fail and block the merge.