### PR TITLE
Ensure `hasRelated` suports model relationships with a collection of models.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",

--- a/src/internal-model.js
+++ b/src/internal-model.js
@@ -79,8 +79,12 @@ export default Model.extend({
     return relationship
   },
 
+  getRelationshipData (relationName, strict = true) {
+    return _.result(this.getRelationship(relationName, strict), 'data')
+  },
+
   getRelationshipType (relationName) {
-    const relationship = _.result(this.getRelationship(relationName), 'data')
+    const relationship = this.getRelationshipData(relationName)
 
     if (_.isArray(relationship)) return 'has-many'
 
@@ -90,15 +94,13 @@ export default Model.extend({
   },
 
   hasRelated (relationName) {
-    const relationship = this.getRelationship(relationName, false)
-
-    return !!_.result(relationship, ['data', 'id'])
+    return !_.isEmpty(this.getRelationshipData(relationName, false))
   },
 
   getRelated (relationName, query) {
     const link = this.getRelationshipLink(relationName)
 
-    const related = _.result(this.getRelationship(relationName), 'data')
+    const related = this.getRelationshipData(relationName)
 
     if (!related) return this.fetchRelated(relationName, query)
 
@@ -110,7 +112,7 @@ export default Model.extend({
   fetchRelated (relationName, query) {
     const link = this.getRelationshipLink(relationName)
 
-    const related = _.result(this.getRelationship(relationName), 'data')
+    const related = this.getRelationshipData(relationName)
 
     if (!related) return this.store.fetchUnknown(link, query)
 

--- a/tests/internal-model.spec.js
+++ b/tests/internal-model.spec.js
@@ -108,6 +108,13 @@ let userWithRelationships = {
           related: '/user/1/friends'
         }
       },
+      enemies: {
+        data: [],
+        links: {
+          self: '/user/1/relationships/enemies',
+          related: '/user/1/enemies'
+        }
+      },
       mother: {
         data: {id: 4, type: 'user'},
         links: {
@@ -210,15 +217,23 @@ describe('InternalModel', function () {
     })
 
     it('returns true if the relationship exists', () => {
-      expect(resource.hasRelated('bff')).toBeTruthy()
+      expect(resource.hasRelated('bff')).toBe(true)
+    })
+
+    it('returns true if relationship has a collection of models', () => {
+      expect(resource.hasRelated('friends')).toBe(true)
+    })
+
+    it('returns false if relationship is empty', () => {
+      expect(resource.hasRelated('enemies')).toBe(false)
     })
 
     it('returns false if the relationship does NOT exist', () => {
-      expect(resource.hasRelated('so')).toBeFalsy()
+      expect(resource.hasRelated('so')).toBe(false)
     })
 
     it('returns false if the relationship is invalid', () => {
-      expect(resource.hasRelated('nada')).toBeFalsy()
+      expect(resource.hasRelated('nada')).toBe(false)
     })
   })
 


### PR DESCRIPTION
Model relationships can be of two types: single results "belongs-to" or multiple "has-many". This is currently supported by `getRelated` and `fetchRelated` but not `hasRelated`. This PR ensures that `hasRelated` can be reliably used to check that a relationship contains a collection of models.

Currently instead of using `hasRelated` clients typically check the relationship result using `this.model.getRelationship('relationshipName').data.length` but this is prone to error. If the relationship does not exist or is not returned `null is not an object` TypeErrors will occur. Now these instances can be replaced with `this.model.hasRelated('relationshipName')`