### PR TITLE
Add documentation for "public" API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ workflows:
       - docs-build:
          requires:
            - install-deps
+           - test
 
       - publish:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,39 @@ jobs:
 
       - run: yarn test
 
+  docs-build:
+     <<: *defaults
+     steps:
+       - restore_cache:
+           keys:
+             - v5-repo-{{ .Environment.CIRCLE_SHA1 }}
+ 
+       - restore_cache:
+           keys:
+             - v5-npm-dependencies-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
+ 
+       - run:
+           name: Generate docs to build
+           command: npm run docs:build
+
+       - run:
+          name: Disable jekyll builds
+          command: touch docs/.nojekyll
+ 
+       - run:
+           name: Configure CircleCi deployment
+           command: |
+             git config user.email "icunningham@grove.co"
+             git config user.name "CircleCi Doc Deploy Backbone.Store"
+
+       - add_ssh_keys:
+           fingerprints:
+             - "cf:11:c6:b2:2d:e3:31:b9:a9:ca:18:dd:99:27:ae:ab"
+
+       - run:
+           name: Deploy docs to gh-pages branch
+           command: npm run gh-pages-deploy
+
   publish:
     <<: *defaults
     steps:
@@ -104,10 +137,15 @@ workflows:
           requires:
             - install-deps
 
+      - docs-build:
+         requires:
+           - install-deps
+
       - publish:
           requires:
             - lint
             - test
+            - docs-build
           filters:
             branches:
               only: -none-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,41 +69,41 @@ jobs:
       - run: yarn test
 
   docs-build:
-     <<: *defaults
-     steps:
-       - restore_cache:
-           keys:
-             - v5-repo-{{ .Environment.CIRCLE_SHA1 }}
+    <<: *defaults
+    steps:
+      - restore_cache:
+          keys:
+            - v5-repo-{{ .Environment.CIRCLE_SHA1 }}
  
-       - restore_cache:
-           keys:
-             - v5-npm-dependencies-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
+      - restore_cache:
+          keys:
+            - v5-npm-dependencies-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
  
-       - run:
-           name: Generate docs to build
-           command: npm run docs:build
+      - run:
+          name: Generate docs to build
+          command: npm run docs:build
 
-       - run:
-          name: Disable jekyll builds
-          command: touch docs/.nojekyll
+      - run:
+         name: Disable jekyll builds
+         command: touch docs/.nojekyll
  
-       - run:
-           name: Configure CircleCi deployment
-           command: |
-             git config user.email "icunningham@grove.co"
-             git config user.name "CircleCi Doc Deploy Backbone.Store"
+      - run:
+          name: Configure CircleCi deployment
+          command: |
+            git config user.email "icunningham@grove.co"
+            git config user.name "CircleCi Doc Deploy Backbone.Store"
 
-       - add_ssh_keys:
-           fingerprints:
-             - "cf:11:c6:b2:2d:e3:31:b9:a9:ca:18:dd:99:27:ae:ab"
+      - add_ssh_keys:
+          fingerprints:
+            - "cf:11:c6:b2:2d:e3:31:b9:a9:ca:18:dd:99:27:ae:ab"
 
-       - run:
-           name: Deploy docs to gh-pages branch
-           command: |
-               mkdir -p ~/.ssh
-               touch known_hosts
-               ssh-keyscan github.com >> ~/.ssh/known_hosts
-               npm run gh-pages-deploy
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: |
+              mkdir -p ~/.ssh
+              touch known_hosts
+              ssh-keyscan github.com >> ~/.ssh/known_hosts
+              npm run gh-pages-deploy
 
   publish:
     <<: *defaults
@@ -142,9 +142,9 @@ workflows:
             - install-deps
 
       - docs-build:
-         requires:
-           - install-deps
-           - test
+          requires:
+            - install-deps
+            - test
 
       - publish:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,11 @@ jobs:
 
        - run:
            name: Deploy docs to gh-pages branch
-           command: npm run gh-pages-deploy
+           command: |
+               mkdir -p ~/.ssh
+               touch known_hosts
+               ssh-keyscan github.com >> ~/.ssh/known_hosts
+               npm run gh-pages-deploy
 
   publish:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:9.7.1
+    - image: circleci/node:latest
 
 version: 2
 
@@ -68,42 +68,37 @@ jobs:
 
       - run: yarn test
 
-  docs-build:
+  docs:
     <<: *defaults
     steps:
       - restore_cache:
           keys:
             - v5-repo-{{ .Environment.CIRCLE_SHA1 }}
- 
+
       - restore_cache:
           keys:
             - v5-npm-dependencies-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
- 
-      - run:
-          name: Generate docs to build
-          command: npm run docs:build
-
-      - run:
-         name: Disable jekyll builds
-         command: touch docs/.nojekyll
- 
-      - run:
-          name: Configure CircleCi deployment
-          command: |
-            git config user.email "icunningham@grove.co"
-            git config user.name "CircleCi Doc Deploy Backbone.Store"
 
       - add_ssh_keys:
           fingerprints:
             - "cf:11:c6:b2:2d:e3:31:b9:a9:ca:18:dd:99:27:ae:ab"
 
+      - checkout
       - run:
-          name: Deploy docs to gh-pages branch
+          name: Checkout existing `gh-pages` as `docs`
+          command: git worktree add docs gh-pages
+
+      - run:
+          name: Update `docs` via `npm run build:docs`
+          command: npm run build:docs
+
+      - run:
+          name: Commit `docs` to `gh-pages`
           command: |
-              mkdir -p ~/.ssh
-              touch known_hosts
-              ssh-keyscan github.com >> ~/.ssh/known_hosts
-              npm run gh-pages-deploy
+            pushd docs
+            git add .
+            git commit -m '[skip ci] publishing docs' --author 'CircleCI <engineering@grove.co>'
+            git push origin gh-pages
 
   publish:
     <<: *defaults
@@ -141,16 +136,21 @@ workflows:
           requires:
             - install-deps
 
-      - docs-build:
+      - docs:
           requires:
             - install-deps
             - test
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /v[0-9]+(\.[0-9]+){2}/
 
       - publish:
           requires:
             - lint
             - test
-            - docs-build
+            - docs
           filters:
             branches:
               only: -none-

--- a/README.md
+++ b/README.md
@@ -142,29 +142,3 @@ let parser = new BackboneStore.JsonApiParser();
 let adapter = new BackboneStore.HttpAdapter('/api/blog/', parser);
 let repo = new BackboneStore.Repository(BlogModel, adapter);
 ```
-
-### Instantiating a Store
-
-Store is a singleton with 'private' constructor. To get a Store instance use `instance` static method:
-
-```javascript
-import BackboneStore from 'backbone.store'
-
-let store = BackboneStore.Store.instance();
-```
-
-Then you register you repositories in store:
-
-```javascript
-import BackboneStore from 'backbone.store'
-import BlogModel from './path/to/blog-model'
-
-let parser = new BackboneStore.JsonApiParser();
-let adapter = new BackboneStore.HttpAdapter('/api/blog/', parser);
-let repo = new BackboneStore.Repository(BlogModel, adapter);
-
-let store = BackboneStore.Store.instance();
-
-// model name is the same as in defining models
-store.register('blog', repo);
-```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "babel src --out-dir dist",
     "build:watch": "babel --watch src --out-dir dist",
     "test": "jest ./tests",
-    "lint": "eslint ./src/index.js"
+    "lint": "eslint ./src/index.js",
+    "docs:build": "documentation build src/** -f html -o docs-html --project-name Backbone.Store"
   },
   "dependencies": {
     "backbone": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "build:watch": "babel --watch src --out-dir dist",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",
     "test": "jest ./tests",
-    "lint": "eslint ./src/index.js",
-    "gh-pages-deploy": "gh-pages --dotfiles --message '[skip ci] Updates' --dist docs"
+    "lint": "eslint ./src/index.js"
   },
   "dependencies": {
     "backbone": "^1.3.3",
@@ -28,7 +27,6 @@
     "eslint-plugin-jest": "^19.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "gh-pages": "^2.0.1",
     "jest": "^22.4.0",
     "jest-junit": "^1.3.0",
     "jsdoc": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",
     "build:watch": "babel --watch src --out-dir dist",
+    "build:docs": "jsdoc --readme README.md src/* -d ./docs",
     "test": "jest ./tests",
     "lint": "eslint ./src/index.js",
-    "docs:build-dev": "node_modules/.bin/jsdoc --readme README.md src/* -d ./docs",
-    "docs:build": "jsdoc --readme README.md src/* -d ./docs",
     "gh-pages-deploy": "gh-pages --dotfiles --message '[skip ci] Updates' --dist docs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build:watch": "babel --watch src --out-dir dist",
     "test": "jest ./tests",
     "lint": "eslint ./src/index.js",
-    "docs:build": "documentation build src/** -f html -o docs-html --project-name Backbone.Store"
+    "docs:build-dev": "node_modules/.bin/jsdoc --readme README.md src/* -d ./docs",
+    "docs:build": "jsdoc --readme README.md src/* -d ./docs",
+    "gh-pages-deploy": "gh-pages --dotfiles --message '[skip ci] Updates' --dist docs"
   },
   "dependencies": {
     "backbone": "^1.3.3",
@@ -27,8 +29,10 @@
     "eslint-plugin-jest": "^19.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "gh-pages": "^2.0.1",
     "jest": "^22.4.0",
     "jest-junit": "^1.3.0",
+    "jsdoc": "^3.6.2",
     "sinon": "^1.17.2"
   },
   "jest": {

--- a/src/camelcase-dash.js
+++ b/src/camelcase-dash.js
@@ -1,4 +1,4 @@
-/**
+/***
 * Convert dash string to camelCase.
 * @param {string} str - String to convert.
 * @returns {string} Converted string.
@@ -7,7 +7,7 @@ export function camelize (str) {
   return str.replace(/-([a-z0-9])/g, match => match[1].toUpperCase())
 }
 
-/**
+/***
 * Convert camelCase string to dash.
 * @param {string} str - String to convert.
 * @returns {string} Converted string.

--- a/src/collection-proxy.js
+++ b/src/collection-proxy.js
@@ -1,6 +1,12 @@
 import _ from 'underscore'
 import {Collection, Events} from 'backbone'
 
+/**
+ * A Proxy object for a { Backbone.Collection }. All methods
+ * for Backbone Collections are defined for the CollectionProxy
+ * class.
+ * @param { Collection }
+ */
 class CollectionProxy {
   constructor (content) {
     if (content == null) {

--- a/src/collection-proxy.js
+++ b/src/collection-proxy.js
@@ -2,7 +2,7 @@ import _ from 'underscore'
 import {Collection, Events} from 'backbone'
 
 /**
- * A Proxy object for a { Backbone.Collection }. All methods
+ * A Proxy object for a {@link https://backbonejs.org/#Collection Backbone.Collection}. All methods
  * for Backbone Collections are defined for the CollectionProxy
  * class.
  * @param { Collection }

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -1,11 +1,16 @@
-/**
+/***
  * HttpAdapter
  * @module
  */
 import {ajax} from 'jquery'
 
 /**
- * Adapter which works with data over HTTP.
+ * Adapter which works with data over HTTP, based on the options that
+ * are passed to it's constructor. This class is responsible for
+ * any CRUD operations that need to be carried out with your JSON:API service
+ * from within the Backbone.Store.
+ * @param {Object} options -  An object that contains a property, `urlPrefix`,
+ * that defines the REST service that will be returning a JSON:API response
  */
 class HttpAdapter {
   constructor (options = {}) {
@@ -28,6 +33,7 @@ class HttpAdapter {
 
   /**
    * Get entity by link.
+   * @private
    * @param {string} link - Link to entity.
    * @returns {Promise} Promise for fetched data.
    */
@@ -38,6 +44,7 @@ class HttpAdapter {
 
   /**
    * Create entity.
+   * @private
    * @param {string} link - Entity url.
    * @param {object} attributes - Data to create entity with.
    * @returns {Promise} Promise for created data.
@@ -49,6 +56,7 @@ class HttpAdapter {
 
   /**
    * Update entity.
+   * @private
    * @param {string} link - Entity url.
    * @param {object} attributes - Data to update entity with.
    * @returns {Promise} Promise for updated data.
@@ -60,6 +68,7 @@ class HttpAdapter {
 
   /**
    * Destroy entity.
+   * @private
    * @param {string} link - Entity self link.
    * @returns {Promise} Promise for destroy.
    */

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -7,10 +7,10 @@ import {ajax} from 'jquery'
 /**
  * Adapter which works with data over HTTP, based on the options that
  * are passed to it's constructor. This class is responsible for
- * any CRUD operations that need to be carried out with your JSON:API service
+ * any CRUD operations that need to be carried out with your {@link https://jsonapi.org/ JSON:API} service
  * from within the Backbone.Store.
  * @param {Object} options -  An object that contains a property, `urlPrefix`,
- * that defines the REST service that will be returning a JSON:API response
+ * that defines the REST service that will be returning a {@link https://jsonapi.org/ JSON:API} response
  */
 class HttpAdapter {
   constructor (options = {}) {

--- a/src/json-api-parser.js
+++ b/src/json-api-parser.js
@@ -1,4 +1,4 @@
-/**
+/***
  * JsonApiParser.
  * @module
  */
@@ -6,6 +6,7 @@ import _ from 'underscore'
 import {camelize, decamelize} from './camelcase-dash'
 
 /**
+ * @private
  * Parser that parses a resource in JSON API format to BackboneStore format.
  */
 class JsonApiParser {

--- a/src/model-proxy.js
+++ b/src/model-proxy.js
@@ -2,8 +2,8 @@ import _ from 'underscore'
 import {Events, Model} from 'backbone'
 
 /**
- * A Proxy object for an {internal-store}. All methods
- * for Backbone Models as well as methods from internal-model
+ * A Proxy object for an {internal-model}. All methods
+ * for {@link https://backbonejs.org/#Model Backbone.Model} as well as methods from internal-model
  * are defined.
  * @param { content: internal-model }
  */

--- a/src/model-proxy.js
+++ b/src/model-proxy.js
@@ -1,6 +1,12 @@
 import _ from 'underscore'
 import {Events, Model} from 'backbone'
 
+/**
+ * A Proxy object for an {internal-store}. All methods
+ * for Backbone Models as well as methods from internal-model
+ * are defined.
+ * @param { content: internal-model }
+ */
 class ModelProxy {
   constructor (content) {
     if (content == null) {

--- a/src/model-proxy.js
+++ b/src/model-proxy.js
@@ -5,7 +5,7 @@ import {Events, Model} from 'backbone'
  * A Proxy object for an {internal-model}. All methods
  * for {@link https://backbonejs.org/#Model Backbone.Model} as well as methods from internal-model
  * are defined.
- * @param { content: internal-model }
+ * @param { internal-model }
  */
 class ModelProxy {
   constructor (content) {

--- a/src/repository.js
+++ b/src/repository.js
@@ -5,8 +5,8 @@
 import RepositoryCollection from './repository-collection'
 
 /**
- * @private
  * Repository class which provides access to entities and stores them.
+ * @private
  */
 class Repository {
   constructor () {

--- a/src/repository.js
+++ b/src/repository.js
@@ -1,10 +1,11 @@
-/**
+/***
  * Repository.
  * @module
  */
 import RepositoryCollection from './repository-collection'
 
 /**
+ * @private
  * Repository class which provides access to entities and stores them.
  */
 class Repository {

--- a/src/store.js
+++ b/src/store.js
@@ -305,7 +305,7 @@ class Store {
    * Creates an internal-model that will be stored in the Store's
    * cache.
    * @param {internal-model} resource
-   * @returns {void}
+   * @returns { Promise<ModelProxy> }
    */
   create (resource) {
     let data = this._parser.serialize(resource.attributes)
@@ -322,7 +322,7 @@ class Store {
    * Updates a given model
    * @param {Model} resource - Model to be updated
    * @param {Object} options - Object that contains the data that will be used in the update
-   * @returns {Promise}
+   * @returns { Promise }
    */
   update (resource, options) {
     let data

--- a/src/store.js
+++ b/src/store.js
@@ -13,7 +13,7 @@ import CollectionProxy from './collection-proxy'
 import querystring from 'querystring'
 
 /**
- * Backbone Store class that manages all JSON API responses
+ * Backbone Store class that manages all {@link https://jsonapi.org/ JSON:API} formatted responses
  * and caching.
  * @param {HttpAdapter} adapter - Adapter to any data source.
  */
@@ -27,15 +27,20 @@ class Store {
   }
 
   /**
-   * Register repository in Store.
-   * @param {string} modelName - model name that is used in relations definitions.
+   * Register a Model to be added into a store
+   * @param {String} modelName - model name that is used in relations definitions.
    * @param {Function} definition - Model or collection class.
+   * @returns {void}
    */
   register (modelName, definition = {}) {
     this._modelDefinitions[modelName] = definition
   }
 
-  // return internal-model
+  /***
+   *
+   * @param {String} modelName - Name of the model to be returned
+   * @returns {internal-model}
+   */
   modelFor (modelName) {
     let definition = this._modelDefinitions[modelName]
 
@@ -47,9 +52,9 @@ class Store {
   }
 
   /**
-   * Push a raw JSON API document into the store.
-   * @param {string} modelName - model name that is used in relations definitions.
-   * @param {Function} resource - a JSON API document
+   * Push a raw {@link https://jsonapi.org/ JSON:API} formatted resource into the store.
+   * @param {Object} resource - a {@link https://jsonapi.org/ JSON:API} resource
+   * @returns {internal-model | Collection}
    */
   push (resource) {
     let {data, included} = resource
@@ -94,12 +99,11 @@ class Store {
     return model
   }
 
-  // returns internal model
   /**
    * Build an internal model for the store with the objects attributes
    * attached.
-   * @param {string} modelName - The name of the model that has been registered within the Store
-   * @param {Object} attributes - JSON:API formatted object literal used to build
+   * @param {String} modelName - The name of the model that has been registered within the Store
+   * @param {Object} attributes - {@link https://jsonapi.org/ JSON:API} formatted object literal used to build
    * @returns {internal-model}
    */
   build (modelName, attributes) {
@@ -131,7 +135,7 @@ class Store {
   /**
    * Clones (copies) an Object using deep copying.
    *
-   * @param { Object } model -  A JSON:API formatted object
+   * @param { Object } model -  A {@link https://jsonapi.org/ JSON:API} formatted object
    * @returns { internal-model }
    */
   clone (model) {
@@ -146,12 +150,11 @@ class Store {
     return this.build(newAttributes._type, newAttributes)
   }
 
-  // returns ModelProxy
   /**
    * Get model by Id or link. If model is cached on front-end it will be returned from cache, otherwise it will be
    * fetched.
    * @param { String } link - Model link.
-   * @returns { Promise } Promise for requested model.
+   * @returns { Promise<ModelProxy> } Promise for requested model.
    */
   get (type, id, query) {
     let model = this.peek(type, id)
@@ -162,11 +165,10 @@ class Store {
     }
   }
 
-  // returns ModelProxy
   /**
    * Fetch model by Id or link from server.
-   * @param {string} link - Model link.
-   * @returns {Promise} Promise for requested model of type ModelProxy.
+   * @param {String} link - Model link.
+   * @returns {Promise<ModelProxy>} Promise for requested model of type ModelProxy.
    */
   fetch (type, id, options = {}) {
     let {query, link} = options
@@ -207,12 +209,12 @@ class Store {
     return this._pending[key]
   }
 
-  // returns ModelProxy
   /**
    * Get model by Type and Id from front-end cache.
-   * @param {string} type - Model type.
-   * @param {string|number} id - Model id.
-   * @returns {ModelProxy} Requested model.
+   * @param {String} type - Model type.
+   * @param {String | Number} id - Model id.
+   * @returns {ModelProxy | void} A ModelProxy if the requesting model
+   * is already cached, else nothing is returned.
    */
   peek (type, id) {
     let resource = this._repository.get(`${type}__${id}`)
@@ -222,7 +224,11 @@ class Store {
     }
   }
 
-  // Returns CollectionProxy
+  /***
+   *
+   * @param {Object} all - All objects
+   * @returns {CollectionProxy}
+   */
   peekMany (all) {
     let result = new Collection()
     result._incomplete = false
@@ -239,9 +245,9 @@ class Store {
     }, result))
   }
 
-  // returns ModelProxy
   /**
    * @private
+   * @returns {ModelProxy}
    */
   getBelongsTo (owner, link, type, id, query) {
     let model = this.peek(type, id)
@@ -252,9 +258,9 @@ class Store {
     }
   }
 
-  // returns ModelProxy
   /**
    * @private
+   * @returns {ModelProxy}
    */
   fetchBelongsTo (owner, link, type, id, query) {
     return this.fetch(type, id, {link, query})
@@ -272,9 +278,9 @@ class Store {
     }
   }
 
-  // returns CollectionProxy
   /**
    * @private
+   * @returns {CollectionProxy}
    */
   fetchHasMany (owner, models, link, query) {
     if (!models) {
@@ -287,9 +293,9 @@ class Store {
     return result
   }
 
-  // returns Object
   /**
    * @private
+   * @returns {Object}
    */
   fetchUnknown (link, query) {
     return this._fetch(link, query)
@@ -299,6 +305,7 @@ class Store {
    * Creates an internal-model that will be stored in the Store's
    * cache.
    * @param {internal-model} resource
+   * @returns {void}
    */
   create (resource) {
     let data = this._parser.serialize(resource.attributes)
@@ -315,6 +322,7 @@ class Store {
    * Updates a given model
    * @param {Model} resource - Model to be updated
    * @param {Object} options - Object that contains the data that will be used in the update
+   * @returns {Promise}
    */
   update (resource, options) {
     let data
@@ -347,6 +355,7 @@ class Store {
   /**
    * Remove a record from a server and then from the cache.
    * @param {Model} resource - A Model to be deleted
+   * @return {Promise}
    */
   destroy (resource) {
     return this._adapter


### PR DESCRIPTION
Adding JSDocs documentation for `Backbone.Store`'s "public" API. To generate doc's locally on your machine run `npm run build:docs`

For adding documentation through comments, your comments will have to start with `/**`. JSDocs won't include any comments that start with `//`, `/***`, or include any comments containing `@private`.

The docs will be generated by CircleCi whenever a change is merged into `master`