### PR TITLE
Bump to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "prepack": "npm run build",
     "build": "babel src --out-dir dist",


### PR DESCRIPTION
Because `0.3.1` is already published: https://www.npmjs.com/package/@groveco/backbone.store/v/0.3.1