### PR TITLE
Fetch `gh-pages` in circleci doc build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,11 @@ jobs:
             - "cf:11:c6:b2:2d:e3:31:b9:a9:ca:18:dd:99:27:ae:ab"
 
       - checkout
+
+      - run:
+          name: Fetch `gh-pages`
+          command: git fetch origin gh-pages:gh-pages
+
       - run:
           name: Checkout existing `gh-pages` as `docs`
           command: git worktree add docs gh-pages


### PR DESCRIPTION
Currently, generating the docs fails because the
`docs` job within circleci is unable to find a branch called
`gh-pages`. The theory is that if we fetch our remote `gh-pages`
branch, then we'll be able to properly build and deploy the docs
to `gh-pages`.