### PR TITLE
Circleci set GitHub user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,11 @@ jobs:
       - checkout
 
       - run:
-          name: Fetch `gh-pages`
-          command: git fetch origin gh-pages:gh-pages
+          name: Fetch `gh-pages` and set user
+          command: |
+            git fetch origin gh-pages:gh-pages
+            git config user.email "engineering@grove.co"
+            git config user.name "CircleCI"
 
       - run:
           name: Checkout existing `gh-pages` as `docs`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: |
             pushd docs
             git add .
-            git commit -m '[skip ci] publishing docs' --author 'CircleCI <engineering@grove.co>'
+            git commit -m '[skip ci] publishing docs'
             git push origin gh-pages
 
   publish:


### PR DESCRIPTION
So it appears that setting the author within the commit isn't sufficient for circleci to push docs to our `gh-pages` branch. We also need to set a user name and email:

https://circleci.com/gh/groveco/backbone.store/532

Hopefully this is the final piece that we need to start consistently publishing documentation.