### PR TITLE
Add serialize requests mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "dist/index.js",
   "version": "0.3.2",
   "scripts": {
-    "prepack": "npm run build",
+    "prepack": "NODE_ENV=development npm install && npm run build",
     "build": "babel src --out-dir dist",
     "build:watch": "babel --watch src --out-dir dist",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -15,6 +15,9 @@ import {ajax} from 'jquery'
 class HttpAdapter {
   constructor (options = {}) {
     this.urlPrefix = options.urlPrefix
+
+    this.serializeRequests = false
+    this._outstandingRequests = new Set()
   }
 
   buildUrl (type, id) {
@@ -86,35 +89,54 @@ class HttpAdapter {
       data = JSON.stringify(data)
     }
 
-    return new Promise((resolve, reject) => {
-      let request = {
-        url,
-        type,
-        headers,
-        success: (data, textStatus, jqXhr) => {
-          if (!data && jqXhr.status !== 204) {
-            throw new Error(`request returned ${jqXhr.status} status without data`)
-          }
-          return resolve(data)
-        },
-        error: (response) => {
-          if (response.readyState === 0 || response.status === 0) {
-            // this is a canceled request, so we literally should do nothing
-            return
-          }
+    const makeRequest = () => {
+      return new Promise((resolve, reject) => {
+        let request = {
+          url,
+          type,
+          headers,
+          success: (data, textStatus, jqXhr) => {
+            if (!data && jqXhr.status !== 204) {
+              throw new Error(`request returned ${jqXhr.status} status without data`)
+            }
+            return resolve(data)
+          },
+          error: (response) => {
+            if (response.readyState === 0 || response.status === 0) {
+              // this is a canceled request, so we literally should do nothing
+              return
+            }
 
-          const error = new Error(`request for resource, ${url}, returned ${response.status} ${response.statusText}`)
-          error.response = response
-          reject(error)
-        },
-        // being explicit about data type so jQuery doesn't "intelligent guess" wrong
-        // changing this may not break tests, but does behave badly in prod
-        dataType: 'text',
-        data
-      }
+            const error = new Error(`request for resource, ${url}, returned ${response.status} ${response.statusText}`)
+            error.response = response
+            reject(error)
+          },
+          // being explicit about data type so jQuery doesn't "intelligent guess" wrong
+          // changing this may not break tests, but does behave badly in prod
+          dataType: 'text',
+          data
+        }
 
-      ajax(request)
-    })
+        ajax(request)
+      })
+    }
+
+    let promise
+    if (this._serializeRequests) {
+      // Wait for all requests to settle (either with success or rejection) before making request
+      promise = Promise.all(Array.from(this._outstandingRequests).map(promise => promise.catch(() => {})))
+        .then(makeRequest)
+    } else {
+      promise = makeRequest()
+    }
+
+    this._outstandingRequests.add(promise)
+    const removeFromOutstandingRequests = () =>{
+      this._outstandingRequests.delete(promise)
+    }
+    promise.then(removeFromOutstandingRequests, removeFromOutstandingRequests)
+
+    return promise
   }
 }
 

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -122,7 +122,7 @@ class HttpAdapter {
     }
 
     let promise
-    if (this._serializeRequests) {
+    if (this.serializeRequests) {
       // Wait for all requests to settle (either with success or rejection) before making request
       promise = Promise.all(Array.from(this._outstandingRequests).map(promise => promise.catch(() => {})))
         .then(makeRequest)

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -124,7 +124,10 @@ class HttpAdapter {
     let promise
     if (this.serializeRequests) {
       // Wait for all requests to settle (either with success or rejection) before making request
-      promise = Promise.all(Array.from(this._outstandingRequests).map(promise => promise.catch(() => {})))
+      const promises = Array.from(this._outstandingRequests)
+        .map(promise => promise.catch(() => {}))
+
+      promise = Promise.all(promises)
         .then(makeRequest)
     } else {
       promise = makeRequest()

--- a/src/store.js
+++ b/src/store.js
@@ -26,11 +26,29 @@ class Store {
     this._modelDefinitions = {}
   }
 
-  get serializeRequests() {
+  /**
+   * Toggles whether requests are forced to run sequentially.
+   *
+   * Defaults to `false`.
+   *
+   * @example
+   *    const store = new Store(new HttpAdapter({urlPrefix: '/api/'}))
+   *
+   *    const fetch1 = store.get('customer', '20')
+   *    store.serializeRequests = true
+   *    // Will not start until fetch1 completes
+   *    const fetch2 = store.get('offer', '30')
+   *    // Will not start until fetch2 (and transitively fetch1) complete
+   *    const fetch3 = store.get('whatever', '90')
+   *    store.serializeRequests = false
+   *    // Will start immediately
+   *    const fetch4 = store.get('something', '120')
+   */
+  get serializeRequests () {
     return this._adapter.serializeRequests
   }
 
-  set serializeRequests(value) {
+  set serializeRequests (value) {
     this._adapter.serializeRequests = value
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -26,6 +26,14 @@ class Store {
     this._modelDefinitions = {}
   }
 
+  get serializeRequests() {
+    return this._adapter.serializeRequests
+  }
+
+  set serializeRequests(value) {
+    this._adapter.serializeRequests = value
+  }
+
   /**
    * Register a Model to be added into a store
    * @param {String} modelName - model name that is used in relations definitions.

--- a/src/store.js
+++ b/src/store.js
@@ -49,7 +49,7 @@ class Store {
   }
 
   set serializeRequests (value) {
-    this._adapter.serializeRequests = value
+    this._adapter.serializeRequests = !!value
   }
 
   /**

--- a/tests/http-adapter.spec.js
+++ b/tests/http-adapter.spec.js
@@ -3,11 +3,9 @@ import sinon from 'sinon'
 
 describe('HTTP adapter', function () {
   let adapter, server
-  beforeAll(function () {
-    adapter = new HttpAdapter()
-  })
 
   beforeEach(function () {
+    adapter = new HttpAdapter()
     server = sinon.fakeServer.create({autoRespond: true})
     server.respondImmediately = true
   })
@@ -96,6 +94,105 @@ describe('HTTP adapter', function () {
       server.respondWith('DELETE', '/api/user/42/', [204, {}, ''])
 
       return adapter.destroy('/api/user/42/')
+    })
+  })
+
+  describe('#serializeRequests', function () {
+    it('parallel requests do not start when `serializeRequests = true`', async function () {
+      server.autoRespond = false
+      server.respondImmediately = false
+
+      // Turn on `serializeRequests` and then make two parallel requests
+      adapter.serializeRequests = true
+      adapter.get('/api/user/42/')
+      adapter.get('/api/offer/9000/')
+
+      // Tick microtask queue
+      await Promise.resolve().then(() => {})
+
+      expect(server.requests).toHaveLength(1)
+      expect(server.requests[0].url).toEqual('/api/user/42/')
+    })
+
+    it('parallel requests do not start when `serializeRequests = true`, even if it was set after the pending request started', async function () {
+      server.autoRespond = false
+      server.respondImmediately = false
+
+      // Turn on `serializeRequests` after making the first request
+      adapter.get('/api/user/42/')
+      adapter.serializeRequests = true
+      adapter.get('/api/offer/9000/')
+
+      // Tick microtask queue
+      await Promise.resolve().then(() => {})
+
+      expect(server.requests).toHaveLength(1)
+      expect(server.requests[0].url).toEqual('/api/user/42/')
+    })
+
+    it('sequential requests start after previous finishes when `serializeRequests = true`', async function () {
+      server.autoRespond = false
+      server.respondImmediately = false
+
+      // Turn on `serializeRequests` and make some requests
+      adapter.serializeRequests = true
+      const fetch1 = adapter.get('/api/user/42/')
+      const fetch2 = adapter.get('/api/offer/9000/')
+
+      // Tick microtask queue
+      await Promise.resolve().then(() => {})
+
+      expect(server.requests).toHaveLength(1)
+      expect(server.requests[0].url).toEqual('/api/user/42/')
+
+      const payload = {foo: 'bar', fiz: {biz: 'buz'}}
+      server.requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+
+      await fetch1
+
+      // Tick microtask queue
+      await Promise.resolve().then(() => {})
+
+      expect(server.requests).toHaveLength(2)
+      expect(server.requests[1].url).toEqual('/api/offer/9000/')
+
+      const payload2 = {foo2: 'bar', fiz2: {biz: 'buz'}}
+      server.requests[1].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload2))
+
+      await fetch2
+    })
+
+    it('parallel requests are restored after `serializeRequests` is toggled back', async function () {
+      server.autoRespond = false
+      server.respondImmediately = false
+
+      // Turn on `serializeRequests` and make some requests
+      adapter.serializeRequests = true
+      const fetch1 = adapter.get('/api/user/42/')
+      const fetch2 = adapter.get('/api/offer/9000/')
+
+      // Respond to requests
+      await Promise.resolve().then(() => {})
+      const payload = {foo: 'bar', fiz: {biz: 'buz'}}
+      server.requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+      await fetch1
+
+      await Promise.resolve().then(() => {})
+      const payload2 = {foo2: 'bar', fiz2: {biz: 'buz'}}
+      server.requests[1].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+      await fetch2
+
+      // Now try to make requests in parallel
+      adapter.serializeRequests = false
+      adapter.get('/api/something/42/')
+      adapter.get('/api/else/9000/')
+
+      // Tick microtask queue
+      await Promise.resolve().then(() => {})
+
+      expect(server.requests).toHaveLength(4)
+      expect(server.requests[2].url).toEqual('/api/something/42/')
+      expect(server.requests[3].url).toEqual('/api/else/9000/')
     })
   })
 })


### PR DESCRIPTION
Adds the ability to temporarily serialize all requests made during flows where failing to do so can produce race conditions (e.g. password changes which refresh session cookies).

This is done by maintaining a `Set` of outstanding requests, and (when the mode is active) creating a promise that waits for all of them to finish that is combined with the new request promise via `then`.