### PR TITLE
Allow all jobs to run for appropriate tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,18 +131,31 @@ workflows:
   version: 2
   build:
     jobs:
-      - checkout-code
+      - checkout-code:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}$/
+
       - install-deps:
           requires:
             - checkout-code
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}$/
 
       - lint:
           requires:
             - install-deps
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}$/
 
       - test:
           requires:
             - install-deps
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}$/
 
       - docs:
           requires:


### PR DESCRIPTION
It appears CircleCI defaults to not allowing jobs to run on tags, even if that job is a dependent of a job that is allowed to do so: https://discuss.circleci.com/t/builds-for-tags-not-triggering/17681/4