### PR TITLE
Feature/gc 2179 remove $.ajax for fetch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testURL: 'http://localhost/',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js'],
+  setupFiles: ['<rootDir>/tests/setup.js'],
+  testMatch: ['**/tests/**/*.spec.js'],
+  collectCoverage: true,
+  coverageDirectory: './coverage',
+  testResultsProcessor: 'jest-junit'
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "scripts": {
     "prepack": "NODE_ENV=development npm install && npm run build",
     "build": "babel src --out-dir dist",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,5 @@
     "jsdoc": "^3.6.2",
     "node-fetch": "^2.6.0",
     "sinon": "^1.17.2"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "coverageDirectory": "./coverage",
-    "testResultsProcessor": "jest-junit",
-    "testURL": "http://localhost/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,11 @@
     "build": "babel src --out-dir dist",
     "build:watch": "babel --watch src --out-dir dist",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",
-    "test": "jest ./tests",
+    "test": "jest",
     "lint": "eslint ./src/index.js"
   },
   "dependencies": {
-    "clone": "^2.1.0"
-  },
-  "peerDependencies": {
+    "clone": "^2.1.0",
     "backbone": "^1.3.3",
     "underscore": "^1.9.1"
   },
@@ -31,12 +29,12 @@
     "eslint-plugin-jest": "^19.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "fetch-mock": "^7.3.9",
     "jest": "^22.4.0",
     "jest-junit": "^1.3.0",
     "jsdoc": "^3.6.2",
-    "sinon": "^1.17.2",
-    "backbone": "^1.3.3",
-    "underscore": "^1.9.1"
+    "node-fetch": "^2.6.0",
+    "sinon": "^1.17.2"
   },
   "jest": {
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "scripts": {
     "prepack": "NODE_ENV=development npm install && npm run build",
     "build": "babel src --out-dir dist",
@@ -11,11 +11,13 @@
     "lint": "eslint ./src/index.js"
   },
   "dependencies": {
-    "backbone": "^1.3.3",
-    "clone": "^2.1.0",
-    "underscore": "^1.9.1"
+    "clone": "^2.1.0"
   },
   "peerDependencies": {
+    "backbone": "^1.3.3",
+    "underscore": "^1.9.1"
+  },
+  "optionalDependencies": {
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
@@ -32,7 +34,9 @@
     "jest": "^22.4.0",
     "jest-junit": "^1.3.0",
     "jsdoc": "^3.6.2",
-    "sinon": "^1.17.2"
+    "sinon": "^1.17.2",
+    "backbone": "^1.3.3",
+    "underscore": "^1.9.1"
   },
   "jest": {
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "backbone": "^1.3.3",
     "clone": "^2.1.0",
-    "jquery": "^2.2.4",
     "underscore": "^1.9.1"
+  },
+  "peerDependencies": {
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -82,8 +82,9 @@ class HttpAdapter {
 
     if (method === METHOD.GET) {
       // serialize query params
+      body = new URLSearchParams()
       for (let [key, value] of Object.entries(data)) {
-        url.searchParams.append(key, value)
+        body.append(key, value)
       }
     } else if (method.includes(METHOD.POST) || method.includes(METHOD.PATCH)) {
       // Stringify data before any async stuff, just in case it's accidentally a mutable object (e.g.
@@ -115,7 +116,6 @@ class HttpAdapter {
   async _fetch ({method, url, headers, body}) {
     let response = await fetch(url, {
       method,
-      url,
       headers,
       body
     })

--- a/src/http-adapter.js
+++ b/src/http-adapter.js
@@ -8,7 +8,6 @@ const METHOD = Object.freeze({
 class HttpAdapter {
   constructor (options = {}) {
     this.urlPrefix = options.urlPrefix
-
     this.serializeRequests = false
     this._outstandingRequests = new Set()
   }
@@ -77,7 +76,7 @@ class HttpAdapter {
       'Content-Type': 'application/vnd.api+json'
     }
     
-    let body = null
+    let body = {}
     
     url = new URL(url, location.origin)
 
@@ -118,28 +117,19 @@ class HttpAdapter {
       method,
       url,
       headers,
-      ...(body || {})
+      body
     })
-    switch (response.status) {
-      case 200:
-      case 201:
-      case 202:
-      case 203:
-      case 205:
-      case 206:
-        if (response.body == null) {
-          throw new Error(
-            `request returned ${response.status} status without data`
-          )
-        }
-        return await response.json()
-      case 204:
-        return {}
-      default:
+    if (response.status < 300 && response.status >= 200) {
+      if (response.body == null && response.status !== 204) {
         throw new Error(
-          `request for resource, ${url}, returned ${response.status} ${response.statusText}`
+          `request returned ${response.status} status without data`
         )
+      }
+      return await response.json()
     }
+    throw new Error(
+      `request for resource, ${url}, returned ${response.status} ${response.statusText}`
+    )
   }
 }
 

--- a/tests/http-adapter.spec.js
+++ b/tests/http-adapter.spec.js
@@ -1,17 +1,13 @@
 import HttpAdapter from '../src/http-adapter'
-import sinon from 'sinon'
+import fetchMock from 'fetch-mock'
 
 describe('HTTP adapter', function () {
-  let adapter, server
+  let adapter
 
   beforeEach(function () {
     adapter = new HttpAdapter()
-    server = sinon.fakeServer.create({autoRespond: true})
-    server.respondImmediately = true
-  })
-
-  afterEach(function () {
-    server.restore()
+    fetchMock.reset()
+    fetchMock.resetBehavior()
   })
 
   describe('#buildUrl', function () {
@@ -33,166 +29,252 @@ describe('HTTP adapter', function () {
     })
   })
 
-  describe('#get', function () {
-    it('returns a parsed resource from the network', function () {
+  describe('#get', () => {
+    it('returns a parsed resource from the network', async done => {
       let payload = {data: {id: 123, attributes: {foo: 'asdf'}}}
-      server.respondWith('GET', '/api/user/42/', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\/42\//g, payload, {
+        method: 'GET'
+      })
 
-      return adapter.get('/api/user/42/')
-        .then((response) => {
-          expect(response).toEqual(payload)
-        })
+      const response = await adapter.get('api/user/42/')
+      expect(response).toEqual(payload)
+      done()
     })
 
-    it('accepts arbitrary query parameters', function () {
+    it('accepts arbitrary query parameters', async done => {
       let payload = {data: {id: 123, attributes: {foo: 'asdf'}}}
-      server.respondWith('GET', '/api/user/42/?include=bio&foo=bar', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\/42\/\?include=bio&foo=bar/g, payload, {
+        method: 'GET'
+      })
 
-      return adapter.get('/api/user/42/', {include: 'bio', foo: 'bar'})
-        .then((response) => {
-          expect(response).toEqual(payload)
-        })
+      const response = await adapter.get('api/user/42/', {include: 'bio', foo: 'bar'})
+      expect(response).toEqual(payload)
+      done()
     })
 
-    it('returns a meaningful error message', function () {
-      const path = '/api/user/42/'
+    it('returns a meaningful error message', async done => {
+      const path = 'api/user/42/'
       const errorCode = 400
-      server.respondWith('GET', path, [errorCode, {}, ''])
+      fetchMock.mock(/.*api\/user\/42\//g, errorCode, {
+        method: 'GET',
+        status: errorCode,
+        statusText: ''
+      })
 
-      return adapter.get(path)
-        .catch((err) => {
-          expect(err).toBeInstanceOf(Error)
-          expect(err.message).toEqual(expect.stringContaining(path))
-          expect(err.message).toEqual(expect.stringContaining(`${errorCode}`))
-        })
+      try {
+        await adapter.get(path)
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error)
+        expect(err.message).toEqual(expect.stringContaining(path))
+        expect(err.message).toEqual(expect.stringContaining(`${errorCode}`))
+      }
+      done()
     })
   })
 
-  describe('#create', function () {
-    it('creates a new resource on the network', function () {
+  describe('#create', () => {
+    it('creates a new resource on the network', async done => {
       let payload = {data: {foo: 'bar', fiz: {biz: 'buz'}}}
-      server.respondWith('POST', '/api/user/', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\//g, payload, {
+        method: 'POST'
+      })
 
-      return adapter.create('/api/user/', payload)
-        .then((response) => {
-          expect(response).toEqual(payload)
-        })
+      const response = await adapter.create('api/user/', payload)
+      expect(response).toEqual(payload)
+      done()
     })
   })
 
   describe('#update', function () {
-    it('patches a resource on the network', async function () {
+    it('patches a resource on the network', async done => {
       let payload = {foo: 'bar', fiz: {biz: 'buz'}}
-      server.respondWith('PATCH', '/api/user/2/', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\/2\//g, payload, {
+        method: 'PATCH'
+      })
 
-      return expect(adapter.update('/api/user/2/', payload)).resolves.toEqual(payload)
+      const response = await adapter.update('api/user/2/', payload)
+      expect(response).toEqual(payload)
+      done()
     })
   })
 
   describe('#destroy', function () {
-    it('deletes a record from the network', function () {
-      server.respondWith('DELETE', '/api/user/42/', [204, {}, ''])
+    it('deletes a record from the network', async done => {
+      fetchMock.reset()
+      fetchMock.mock(/.*api\/user\/42\//g, 204, {
+        method: 'DELETE'
+      })
 
-      return adapter.destroy('/api/user/42/')
+      const response = await adapter.destroy('api/user/42/')
+      expect(response).toMatchObject({})
+      done()
     })
   })
 
   describe('#serializeRequests', function () {
-    it('parallel requests do not start when `serializeRequests = true`', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+    const path1 = 'api/user/42/'
+    const path2 = 'api/offer/9000/'
+    let fetchAPI
+    beforeEach(() => {
+      // set the fetch api to an interim state since we will be decorating it to run assertions
+      fetchAPI = global.fetch
+    })
+
+    afterEach(() => {
+      // reset the mock state of fetch after each test
+      global.fetch = fetchAPI
+    })
+
+    it('parallel requests do not start and start after previous finishes when `serializeRequests = true`', async done => {
+      const fetchMocked = fetchMock.sandbox().mock('*', {
+        status: 200,
+        method: 'GET',
+        body: {}
+      })
+      let numCalled = 0
+      
+      global.fetch = async function (url, init) {
+        const callOrder = numCalled++
+
+        switch (callOrder) {
+          case 0:
+            expect(url.pathname.includes(path1)).toBe(true)
+            expect(adapter._outstandingRequests.size).toEqual(2)
+            break
+          case 1:
+            expect(url.pathname.includes(path2)).toBe(true)
+            expect(adapter._outstandingRequests.size).toEqual(1)
+            break
+        }
+
+        return await fetchMocked(url, init)
+      }
 
       // Turn on `serializeRequests` and then make two parallel requests
       adapter.serializeRequests = true
-      adapter.get('/api/user/42/')
-      adapter.get('/api/offer/9000/')
-
-      // Tick microtask queue
-      await Promise.resolve().then(() => {})
-
-      expect(server.requests).toHaveLength(1)
-      expect(server.requests[0].url).toEqual('/api/user/42/')
+      adapter.get(path1).then(() => {
+        let calls = fetchMocked.calls()
+        expect(calls).toHaveLength(1)
+        expect(calls[0][0].includes(path1)).toBe(true)
+        expect(adapter._outstandingRequests.size).toEqual(1)
+      })
+      adapter.get(path2).then(() => {
+        let calls = fetchMocked.calls()
+        expect(calls).toHaveLength(2)
+        expect(calls[1][0].includes(path2)).toBe(true)
+        expect(adapter._outstandingRequests.size).toEqual(0)
+        done()
+      })
     })
 
-    it('parallel requests do not start when `serializeRequests = true`, even if it was set after the pending request started', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+    it('parallel requests do not start when `serializeRequests = true`, even if it was set after the pending request started', async done => {
+      const fetchMocked = fetchMock.sandbox().mock('*', {
+        status: 200,
+        method: 'GET',
+        body: {}
+      })
+      let numCalled = 0
+      
+      global.fetch = async function (url, init) {
+        const callOrder = numCalled++
 
-      // Turn on `serializeRequests` after making the first request
-      adapter.get('/api/user/42/')
+        switch (callOrder) {
+          case 0:
+            expect(url.pathname.includes(path1)).toBe(true)
+            //current outstanding requests should be zero since serializeRequests was turned on AFTER the request started
+            expect(adapter._outstandingRequests.size).toEqual(0)
+            break
+          case 1:
+            expect(url.pathname.includes(path2)).toBe(true)
+            expect(adapter._outstandingRequests.size).toEqual(1)
+            break
+        }
+
+        return await fetchMocked(url, init)
+      }
+
+      // Turn on `serializeRequests` and then make two parallel requests
+      
+      adapter.get(path1).then(() => {
+        let calls = fetchMocked.calls()
+        expect(calls).toHaveLength(1)
+        expect(calls[0][0].includes(path1)).toBe(true)
+        expect(adapter._outstandingRequests.size).toEqual(1)
+      })
       adapter.serializeRequests = true
-      adapter.get('/api/offer/9000/')
-
-      // Tick microtask queue
-      await Promise.resolve().then(() => {})
-
-      expect(server.requests).toHaveLength(1)
-      expect(server.requests[0].url).toEqual('/api/user/42/')
+      adapter.get(path2).then(() => {
+        let calls = fetchMocked.calls()
+        expect(calls).toHaveLength(2)
+        expect(calls[1][0].includes(path2)).toBe(true)
+        expect(adapter._outstandingRequests.size).toEqual(0)
+        done()
+      })
     })
 
-    it('sequential requests start after previous finishes when `serializeRequests = true`', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+    it('parallel requests are restored after `serializeRequests` is toggled back', async done => {
+      const fetchMocked = fetchMock.sandbox().mock('*', {
+        status: 200,
+        method: 'GET',
+        body: {}
+      })
+      let numCalled = 0
+      
+      global.fetch = async function (url, init) {
+        const callOrder = numCalled++
 
-      // Turn on `serializeRequests` and make some requests
-      adapter.serializeRequests = true
-      const fetch1 = adapter.get('/api/user/42/')
-      const fetch2 = adapter.get('/api/offer/9000/')
+        switch (callOrder) {
+          case 0:
+            expect(url.pathname.includes(path1)).toBe(true)
+            expect(adapter._outstandingRequests.size).toEqual(2)
+            break
+          case 1:
+            expect(url.pathname.includes(path2)).toBe(true)
+            expect(adapter._outstandingRequests.size).toEqual(1)
+            break
+          case 2:
+            expect(url.pathname.includes(path1)).toBe(true)
+            // expect all requests to be settled right after serialization mode. the queue should be empty
+            expect(adapter._outstandingRequests.size).toEqual(0)
+            break
+          case 3:
+            expect(url.pathname.includes(path2)).toBe(true)
+              // the request can still be in the queue or could have resolved. either are acceptable
+            expect(adapter._outstandingRequests.size === 0 || adapter._outstandingRequests.size === 1).toBe(true)
+            break
+        }
 
-      // Tick microtask queue
-      await Promise.resolve().then(() => {})
+        return await fetchMocked(url, init)
+      }
 
-      expect(server.requests).toHaveLength(1)
-      expect(server.requests[0].url).toEqual('/api/user/42/')
+      const serializeReqFinish = new Promise(resolve => {
+        // Turn on `serializeRequests` and then make two parallel requests
+        adapter.serializeRequests = true
+        adapter.get(path1).then(() => {
+          let calls = fetchMocked.calls()
+          expect(calls).toHaveLength(1)
+          expect(calls[0][0].includes(path1)).toBe(true)
+          expect(adapter._outstandingRequests.size).toEqual(1)
+        })
+        adapter.get(path2).then(() => {
+          let calls = fetchMocked.calls()
+          expect(calls).toHaveLength(2)
+          expect(calls[1][0].includes(path2)).toBe(true)
+          expect(adapter._outstandingRequests.size).toEqual(0)
+          resolve()
+        })
+      })
 
-      const payload = {foo: 'bar', fiz: {biz: 'buz'}}
-      server.requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+      await serializeReqFinish
 
-      await fetch1
-
-      // Tick microtask queue
-      await Promise.resolve().then(() => {})
-
-      expect(server.requests).toHaveLength(2)
-      expect(server.requests[1].url).toEqual('/api/offer/9000/')
-
-      const payload2 = {foo2: 'bar', fiz2: {biz: 'buz'}}
-      server.requests[1].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload2))
-
-      await fetch2
-    })
-
-    it('parallel requests are restored after `serializeRequests` is toggled back', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
-
-      // Turn on `serializeRequests` and make some requests
-      adapter.serializeRequests = true
-      const fetch1 = adapter.get('/api/user/42/')
-      const fetch2 = adapter.get('/api/offer/9000/')
-
-      // Respond to requests
-      await Promise.resolve().then(() => {})
-      const payload = {foo: 'bar', fiz: {biz: 'buz'}}
-      server.requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
-      await fetch1
-
-      await Promise.resolve().then(() => {})
-      const payload2 = {foo2: 'bar', fiz2: {biz: 'buz'}}
-      server.requests[1].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
-      await fetch2
-
-      // Now try to make requests in parallel
       adapter.serializeRequests = false
-      adapter.get('/api/something/42/')
-      adapter.get('/api/else/9000/')
+      adapter.get(path1)
+      adapter.get(path2)
 
-      // Tick microtask queue
-      await Promise.resolve().then(() => {})
-
-      expect(server.requests).toHaveLength(4)
-      expect(server.requests[2].url).toEqual('/api/something/42/')
-      expect(server.requests[3].url).toEqual('/api/else/9000/')
+      const calls = fetchMocked.calls()
+      expect(calls).toHaveLength(4)
+      expect(calls[2][0].includes(path1)).toBe(true)
+      expect(calls[3][0].includes(path2)).toBe(true)
+      done()
     })
   })
 })

--- a/tests/http-adapter.spec.js
+++ b/tests/http-adapter.spec.js
@@ -114,167 +114,84 @@ describe('HTTP adapter', function () {
   describe('#serializeRequests', function () {
     const path1 = 'api/user/42/'
     const path2 = 'api/offer/9000/'
-    let fetchAPI
-    beforeEach(() => {
-      // set the fetch api to an interim state since we will be decorating it to run assertions
-      fetchAPI = global.fetch
-    })
-
-    afterEach(() => {
-      // reset the mock state of fetch after each test
-      global.fetch = fetchAPI
-    })
 
     it('parallel requests do not start and start after previous finishes when `serializeRequests = true`', async done => {
-      const fetchMocked = fetchMock.sandbox().mock('*', {
-        status: 200,
-        method: 'GET',
-        body: {}
-      })
-      let numCalled = 0
-      
-      global.fetch = async function (url, init) {
-        const callOrder = numCalled++
-
-        switch (callOrder) {
-          case 0:
-            expect(url.pathname.includes(path1)).toBe(true)
-            expect(adapter._outstandingRequests.size).toEqual(2)
-            break
-          case 1:
-            expect(url.pathname.includes(path2)).toBe(true)
-            expect(adapter._outstandingRequests.size).toEqual(1)
-            break
-        }
-
-        return await fetchMocked(url, init)
-      }
+      adapter._fetch = jest.fn().mockResolvedValue({})
 
       // Turn on `serializeRequests` and then make two parallel requests
       adapter.serializeRequests = true
-      adapter.get(path1).then(() => {
-        let calls = fetchMocked.calls()
-        expect(calls).toHaveLength(1)
-        expect(calls[0][0].includes(path1)).toBe(true)
-        expect(adapter._outstandingRequests.size).toEqual(1)
-      })
-      adapter.get(path2).then(() => {
-        let calls = fetchMocked.calls()
-        expect(calls).toHaveLength(2)
-        expect(calls[1][0].includes(path2)).toBe(true)
-        expect(adapter._outstandingRequests.size).toEqual(0)
-        done()
-      })
+      adapter.get(path1)
+      adapter.get(path2)
+
+      // Tick microtask queue	
+      await Promise.resolve().then(() => {})
+
+      expect(adapter._fetch.mock.calls.length).toBe(1)
+      expect(adapter._fetch.mock.calls[0][0].url.toString().includes(path1)).toBeTruthy()
+      done()
     })
 
     it('parallel requests do not start when `serializeRequests = true`, even if it was set after the pending request started', async done => {
-      const fetchMocked = fetchMock.sandbox().mock('*', {
-        status: 200,
-        method: 'GET',
-        body: {}
-      })
-      let numCalled = 0
-      
-      global.fetch = async function (url, init) {
-        const callOrder = numCalled++
+      adapter._fetch = jest.fn().mockResolvedValue({})
 
-        switch (callOrder) {
-          case 0:
-            expect(url.pathname.includes(path1)).toBe(true)
-            //current outstanding requests should be zero since serializeRequests was turned on AFTER the request started
-            expect(adapter._outstandingRequests.size).toEqual(0)
-            break
-          case 1:
-            expect(url.pathname.includes(path2)).toBe(true)
-            expect(adapter._outstandingRequests.size).toEqual(1)
-            break
-        }
-
-        return await fetchMocked(url, init)
-      }
-
-      // Turn on `serializeRequests` and then make two parallel requests
-      
-      adapter.get(path1).then(() => {
-        let calls = fetchMocked.calls()
-        expect(calls).toHaveLength(1)
-        expect(calls[0][0].includes(path1)).toBe(true)
-        expect(adapter._outstandingRequests.size).toEqual(1)
-      })
+      const fetch1 = adapter.get(path1)
       adapter.serializeRequests = true
-      adapter.get(path2).then(() => {
-        let calls = fetchMocked.calls()
-        expect(calls).toHaveLength(2)
-        expect(calls[1][0].includes(path2)).toBe(true)
-        expect(adapter._outstandingRequests.size).toEqual(0)
-        done()
-      })
+      const fetch2 = adapter.get(path2)
+
+      // Tick microtask queue	
+      await Promise.resolve().then(() => {})
+
+      expect(adapter._fetch.mock.calls.length).toBe(1)
+      expect(adapter._fetch.mock.calls[0][0].url.toString().includes(path1)).toBeTruthy()
+
+      await fetch1
+
+      // Tick microtask queue	
+      await Promise.resolve().then(() => {})
+
+      expect(adapter._fetch.mock.calls.length).toBe(2)
+      expect(adapter._fetch.mock.calls[1][0].url.toString().includes(path2)).toBeTruthy()
+
+      await fetch2
+      
+      done()
     })
 
     it('parallel requests are restored after `serializeRequests` is toggled back', async done => {
-      const fetchMocked = fetchMock.sandbox().mock('*', {
-        status: 200,
-        method: 'GET',
-        body: {}
-      })
-      let numCalled = 0
-      
-      global.fetch = async function (url, init) {
-        const callOrder = numCalled++
+      adapter._fetch = jest.fn().mockResolvedValue({})
 
-        switch (callOrder) {
-          case 0:
-            expect(url.pathname.includes(path1)).toBe(true)
-            expect(adapter._outstandingRequests.size).toEqual(2)
-            break
-          case 1:
-            expect(url.pathname.includes(path2)).toBe(true)
-            expect(adapter._outstandingRequests.size).toEqual(1)
-            break
-          case 2:
-            expect(url.pathname.includes(path1)).toBe(true)
-            // expect all requests to be settled right after serialization mode. the queue should be empty
-            expect(adapter._outstandingRequests.size).toEqual(0)
-            break
-          case 3:
-            expect(url.pathname.includes(path2)).toBe(true)
-              // the request can still be in the queue or could have resolved. either are acceptable
-            expect(adapter._outstandingRequests.size === 0 || adapter._outstandingRequests.size === 1).toBe(true)
-            break
-        }
+      // Turn on `serializeRequests` and then make two parallel requests
+      adapter.serializeRequests = true
+      const fetch1 = adapter.get(path1)
+      const fetch2 = adapter.get(path2)
 
-        return await fetchMocked(url, init)
-      }
+      // Tick microtask queue	
+      await Promise.resolve().then(() => {})
 
-      const serializeReqFinish = new Promise(resolve => {
-        // Turn on `serializeRequests` and then make two parallel requests
-        adapter.serializeRequests = true
-        adapter.get(path1).then(() => {
-          let calls = fetchMocked.calls()
-          expect(calls).toHaveLength(1)
-          expect(calls[0][0].includes(path1)).toBe(true)
-          expect(adapter._outstandingRequests.size).toEqual(1)
-        })
-        adapter.get(path2).then(() => {
-          let calls = fetchMocked.calls()
-          expect(calls).toHaveLength(2)
-          expect(calls[1][0].includes(path2)).toBe(true)
-          expect(adapter._outstandingRequests.size).toEqual(0)
-          resolve()
-        })
-      })
+      expect(adapter._fetch.mock.calls.length).toBe(1)
+      expect(adapter._fetch.mock.calls[0][0].url.toString().includes(path1)).toBeTruthy()
 
-      await serializeReqFinish
+      await fetch1
+
+      // Tick microtask queue	
+      await Promise.resolve().then(() => {})
+
+      expect(adapter._fetch.mock.calls.length).toBe(2)
+      expect(adapter._fetch.mock.calls[1][0].url.toString().includes(path2)).toBeTruthy()
+
+      await fetch2
 
       adapter.serializeRequests = false
       adapter.get(path1)
       adapter.get(path2)
 
-      const calls = fetchMocked.calls()
-      expect(calls).toHaveLength(4)
-      expect(calls[2][0].includes(path1)).toBe(true)
-      expect(calls[3][0].includes(path2)).toBe(true)
-      done()
+      // Tick microtask queue	
+      await Promise.resolve().then(() => {})
+
+      expect(adapter._fetch.mock.calls.length).toBe(4)
+      expect(adapter._fetch.mock.calls[2][0].url.toString().includes(path1)).toBeTruthy()
+      expect(adapter._fetch.mock.calls[3][0].url.toString().includes(path2)).toBeTruthy()
+      done() 
     })
   })
 })

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,3 @@
+import nodeFetch from 'node-fetch'
+
+global.fetch = nodeFetch


### PR DESCRIPTION
The purpose of this PR is to migrate the http-adapter off of jQuery. jQuery over the years has lost a lot of popularity, increasing the risk of deprecation and support. Multiple libraries, such as jquery-cookie, have already been deprecated. We want to be able to use tools that are well supported incase issues arise. Most jQuery functionality is now natively supported by most browsers. We could use this opportunity to reduce our bundle side while moving strong into the future.

## HTTP Library Evaluation
There are multiple JavaScript HTTP libraries out there for consumption, but how do we pick the right one? The 3 most popular ways of doing this right now are using Axios, Request, or the Fetch API.

### Request
Easily the most popular, request gets over 14 Millions downloads a week. It has very little active development, meaning its either a) very stable, or b) not well supported. I will guess the first. Request is a very large library, coming in at ~180KB zipped. If you want promised based support, add another ~65KB. That's huge!

### Axios
As a lightweight (4.7KB) promise based http client, Axios has gained a lot of popularity. They have made a few releases recently and support instanced http clients as well as global configurations for items like 'headers'. It's a great choice for browser/node http clients and adds a little more opinionated structure for making/handling requests.

Though Axios is awesome, I do not feel it currently fits our use case. There is some functionality that we need to support that makes us feel like we are fighting Axios magic, explicitly our synchronous request mode for caveat cases. Right now I do not feel this is a good contender for us.

### Fetch
Our last option would be fetch, the successor to XHR in modern browsers. Since fetch is native, we do not need to import it as a dependency. This allows us to keep our bundle minimal and guarantee support of the API. It's very easy to use and understand, and allows a less opinionated structure for us to handle our http requests for our current requirements.

Fetch is not currently support in Internet Explorer. Luckily, github has provided its own polyfill library, whatwg-fetch. This polyfill is well supported with over 1.4 million users. We can use this until IE EOL 2025. 

I think this makes fetch the ideal choice for us moving forward and have implemented the following PR in fetch.

## Consumer Changes
This change will require consumers to change the way default headers are set in their app via $.ajax. This could be considered a breaking change and we should version appropriately. Some dependencies have been changed to make the package more bundle reduction friendly. These dependency changes can be changed, of course. Corresponding webapp changes will be discussed in another PR
