### PR TITLE
Remove $.ajax in favor of native fetch in http adapter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testURL: 'http://localhost/',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js'],
+  setupFiles: ['<rootDir>/tests/setup.js'],
+  testMatch: ['**/tests/**/*.spec.js'],
+  collectCoverage: true,
+  coverageDirectory: './coverage',
+  testResultsProcessor: 'jest-junit'
+}

--- a/package.json
+++ b/package.json
@@ -1,24 +1,27 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "scripts": {
     "prepack": "NODE_ENV=development npm install && npm run build",
     "build": "babel src --out-dir dist",
     "build:watch": "babel --watch src --out-dir dist",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",
-    "test": "jest ./tests",
+    "test": "jest",
     "lint": "eslint ./src/index.js"
   },
   "dependencies": {
     "backbone": "^1.3.3",
     "clone": "^2.1.0",
-    "jquery": "^2.2.4",
     "underscore": "^1.9.1"
+  },
+  "optionalDependencies": {
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
@@ -27,15 +30,11 @@
     "eslint-plugin-jest": "^19.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "jest": "^22.4.0",
+    "fetch-mock": "^7.3.9",
+    "jest": "^23.6.0",
     "jest-junit": "^1.3.0",
     "jsdoc": "^3.6.2",
+    "node-fetch": "^2.6.0",
     "sinon": "^1.17.2"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "coverageDirectory": "./coverage",
-    "testResultsProcessor": "jest-junit",
-    "testURL": "http://localhost/"
   }
 }

--- a/tests/collection-proxy.spec.js
+++ b/tests/collection-proxy.spec.js
@@ -156,11 +156,11 @@ describe('CollectionProxy', function () {
     sinon.assert.calledOnce(spyB)
   })
 
-  it('isPending is true when the promise has not been resolved or rejected')
-  it('isResolved is true when the promise has been resolved')
-  it('isResolved is false when the promise has been rejected')
-  it('isRejected is true when the promise has been rejected')
-  it('isRejected is false when the promise has been resolved')
+  it('isPending is true when the promise has not been resolved or rejected', () => {})
+  it('isResolved is true when the promise has been resolved', () => {})
+  it('isResolved is false when the promise has been rejected', () => {})
+  it('isRejected is true when the promise has been rejected', () => {})
+  it('isRejected is false when the promise has been resolved', () => {})
 
   it('sets the content when the promise is resolved', function () {
     let collection = new CollectionProxy(new Collection([{something: 'nothing'}]))

--- a/tests/http-adapter.spec.js
+++ b/tests/http-adapter.spec.js
@@ -1,198 +1,218 @@
 import HttpAdapter from '../src/http-adapter'
-import sinon from 'sinon'
+import fetchMock from 'fetch-mock'
 
-describe('HTTP adapter', function () {
-  let adapter, server
+describe('HTTP adapter', () => {
+  let adapter
 
-  beforeEach(function () {
+  beforeEach(() => {
     adapter = new HttpAdapter()
-    server = sinon.fakeServer.create({autoRespond: true})
-    server.respondImmediately = true
+    fetchMock.reset()
+    fetchMock.resetBehavior()
   })
 
-  afterEach(function () {
-    server.restore()
-  })
-
-  describe('#buildUrl', function () {
-    it('returns the canonical link for a type and id', function () {
+  describe('#buildUrl', () => {
+    it('returns the canonical link for a type and id', () => {
       expect(adapter.buildUrl('foo', 2)).toEqual('/foo/2/')
       expect(adapter.buildUrl(4, 2)).toEqual('/4/2/')
       expect(adapter.buildUrl('foo', 0)).toEqual('/foo/0/')
     })
 
-    it('returns the canonical link for a type', function () {
+    it('returns the canonical link for a type', () => {
       expect(adapter.buildUrl('foo')).toEqual('/foo/')
       expect(adapter.buildUrl(4)).toEqual('/4/')
     })
 
-    it('returns the canonical link with a prefix', function () {
+    it('returns the canonical link with a prefix', () => {
       let adapter = new HttpAdapter({urlPrefix: '/api'})
       expect(adapter.buildUrl('foo', 2)).toEqual('/api/foo/2/')
       expect(adapter.buildUrl('foo')).toEqual('/api/foo/')
     })
   })
 
-  describe('#get', function () {
-    it('returns a parsed resource from the network', function () {
+  describe('#get', () => {
+    it('returns a parsed resource from the network', async () => {
       let payload = {data: {id: 123, attributes: {foo: 'asdf'}}}
-      server.respondWith('GET', '/api/user/42/', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\/42\//g, payload, {
+        method: 'GET'
+      })
 
-      return adapter.get('/api/user/42/')
-        .then((response) => {
-          expect(response).toEqual(payload)
-        })
+      const response = await adapter.get('api/user/42/')
+      expect(response).toEqual(payload)
     })
 
-    it('accepts arbitrary query parameters', function () {
+    it('accepts arbitrary query parameters', async () => {
       let payload = {data: {id: 123, attributes: {foo: 'asdf'}}}
-      server.respondWith('GET', '/api/user/42/?include=bio&foo=bar', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\/42\/\?include=bio&foo=bar/g, payload, {
+        method: 'GET'
+      })
 
-      return adapter.get('/api/user/42/', {include: 'bio', foo: 'bar'})
-        .then((response) => {
-          expect(response).toEqual(payload)
-        })
+      const response = await adapter.get('api/user/42/', {include: 'bio', foo: 'bar'})
+      expect(response).toEqual(payload)
     })
 
-    it('returns a meaningful error message', function () {
+    it('returns a meaningful error message', async () => {
       const path = '/api/user/42/'
       const errorCode = 400
-      server.respondWith('GET', path, [errorCode, {}, ''])
+      fetchMock.mock(/.*api\/user\/42\//g, errorCode, {
+        method: 'GET',
+        status: errorCode,
+        statusText: ''
+      })
 
-      return adapter.get(path)
-        .catch((err) => {
-          expect(err).toBeInstanceOf(Error)
-          expect(err.message).toEqual(expect.stringContaining(path))
-          expect(err.message).toEqual(expect.stringContaining(`${errorCode}`))
-        })
+      try {
+        await adapter.get(path)
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error)
+        expect(err.message).toEqual(expect.stringContaining(path))
+        expect(err.message).toEqual(expect.stringContaining(`${errorCode}`))
+      }
     })
   })
 
-  describe('#create', function () {
-    it('creates a new resource on the network', function () {
+  describe('#create', () => {
+    it('creates a new resource on the network', async () => {
       let payload = {data: {foo: 'bar', fiz: {biz: 'buz'}}}
-      server.respondWith('POST', '/api/user/', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\//g, payload, {
+        method: 'POST'
+      })
 
-      return adapter.create('/api/user/', payload)
-        .then((response) => {
-          expect(response).toEqual(payload)
-        })
+      const response = await adapter.create('api/user/', payload)
+      expect(response).toEqual(payload)
     })
   })
 
-  describe('#update', function () {
-    it('patches a resource on the network', async function () {
+  describe('#update', () => {
+    it('patches a resource on the network', async () => {
       let payload = {foo: 'bar', fiz: {biz: 'buz'}}
-      server.respondWith('PATCH', '/api/user/2/', JSON.stringify(payload))
+      fetchMock.mock(/.*api\/user\/2\//g, payload, {
+        method: 'PATCH'
+      })
 
-      return expect(adapter.update('/api/user/2/', payload)).resolves.toEqual(payload)
+      const response = await adapter.update('api/user/2/', payload)
+      expect(response).toEqual(payload)
     })
   })
 
-  describe('#destroy', function () {
-    it('deletes a record from the network', function () {
-      server.respondWith('DELETE', '/api/user/42/', [204, {}, ''])
+  describe('#destroy', () => {
+    it('deletes a record from the network', async () => {
+      fetchMock.mock(/.*api\/user\/42\//g, 204, {
+        method: 'DELETE'
+      })
 
-      return adapter.destroy('/api/user/42/')
+      const response = await adapter.destroy('api/user/42/')
+      expect(response).toMatchObject({})
     })
   })
 
-  describe('#serializeRequests', function () {
-    it('parallel requests do not start when `serializeRequests = true`', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+  describe('#serializeRequests', () => {
+    const path1 = 'api/user/42/'
+    const path2 = 'api/offer/9000/'
+
+    it('parallel requests do not start and start after previous finishes when `serializeRequests = true`', async () => {
+      adapter._makeRequest = jest.fn().mockResolvedValue({})
 
       // Turn on `serializeRequests` and then make two parallel requests
       adapter.serializeRequests = true
-      adapter.get('/api/user/42/')
-      adapter.get('/api/offer/9000/')
+      adapter.get(path1)
+      adapter.get(path2)
 
       // Tick microtask queue
       await Promise.resolve().then(() => {})
 
-      expect(server.requests).toHaveLength(1)
-      expect(server.requests[0].url).toEqual('/api/user/42/')
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        url: new global.URL(path1, global.location.origin)
+      }))
     })
 
-    it('parallel requests do not start when `serializeRequests = true`, even if it was set after the pending request started', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+    it('parallel requests do not start when `serializeRequests = true`, even if it was set after the pending request started', async () => {
+      adapter._makeRequest = jest.fn().mockResolvedValue({})
 
       // Turn on `serializeRequests` after making the first request
-      adapter.get('/api/user/42/')
+      adapter.get(path1)
       adapter.serializeRequests = true
-      adapter.get('/api/offer/9000/')
+      adapter.get(path2)
 
       // Tick microtask queue
       await Promise.resolve().then(() => {})
 
-      expect(server.requests).toHaveLength(1)
-      expect(server.requests[0].url).toEqual('/api/user/42/')
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        url: new global.URL(path1, global.location.origin)
+      }))
     })
 
-    it('sequential requests start after previous finishes when `serializeRequests = true`', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+    it('sequential requests start after previous finishes when `serializeRequests = true`', async () => {
+      adapter._makeRequest = jest.fn().mockResolvedValue({})
 
-      // Turn on `serializeRequests` and make some requests
       adapter.serializeRequests = true
-      const fetch1 = adapter.get('/api/user/42/')
-      const fetch2 = adapter.get('/api/offer/9000/')
+      const fetch1 = adapter.get(path1)
+      const fetch2 = adapter.get(path2)
 
       // Tick microtask queue
       await Promise.resolve().then(() => {})
 
-      expect(server.requests).toHaveLength(1)
-      expect(server.requests[0].url).toEqual('/api/user/42/')
-
-      const payload = {foo: 'bar', fiz: {biz: 'buz'}}
-      server.requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        url: new global.URL(path1, global.location.origin)
+      }))
 
       await fetch1
 
       // Tick microtask queue
       await Promise.resolve().then(() => {})
 
-      expect(server.requests).toHaveLength(2)
-      expect(server.requests[1].url).toEqual('/api/offer/9000/')
-
-      const payload2 = {foo2: 'bar', fiz2: {biz: 'buz'}}
-      server.requests[1].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload2))
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(2)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        url: new global.URL(path2, global.location.origin)
+      }))
 
       await fetch2
     })
 
-    it('parallel requests are restored after `serializeRequests` is toggled back', async function () {
-      server.autoRespond = false
-      server.respondImmediately = false
+    it('parallel requests are restored after `serializeRequests` is toggled back', async () => {
+      adapter._makeRequest = jest.fn().mockResolvedValue({})
 
       // Turn on `serializeRequests` and make some requests
       adapter.serializeRequests = true
-      const fetch1 = adapter.get('/api/user/42/')
-      const fetch2 = adapter.get('/api/offer/9000/')
+      const fetch1 = adapter.get(path1)
+      const fetch2 = adapter.get(path2)
 
-      // Respond to requests
+      // Tick microtask queue
       await Promise.resolve().then(() => {})
-      const payload = {foo: 'bar', fiz: {biz: 'buz'}}
-      server.requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        url: new global.URL(path1, global.location.origin)
+      }))
+
       await fetch1
 
+      // Tick microtask queue
       await Promise.resolve().then(() => {})
-      const payload2 = {foo2: 'bar', fiz2: {biz: 'buz'}}
-      server.requests[1].respond(200, { "Content-Type": "application/json" }, JSON.stringify(payload))
+
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(2)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        url: new global.URL(path2, global.location.origin)
+      }))
+
       await fetch2
 
       // Now try to make requests in parallel
       adapter.serializeRequests = false
-      adapter.get('/api/something/42/')
-      adapter.get('/api/else/9000/')
+      adapter.get(path1)
+      adapter.get(path2)
 
       // Tick microtask queue
       await Promise.resolve().then(() => {})
 
-      expect(server.requests).toHaveLength(4)
-      expect(server.requests[2].url).toEqual('/api/something/42/')
-      expect(server.requests[3].url).toEqual('/api/else/9000/')
+      expect(adapter._makeRequest).toHaveBeenCalledTimes(4)
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(3, expect.objectContaining({
+        url: new global.URL(path1, global.location.origin)
+      }))
+      expect(adapter._makeRequest).toHaveBeenNthCalledWith(4, expect.objectContaining({
+        url: new global.URL(path2, global.location.origin)
+      }))
     })
   })
 })

--- a/tests/http-adapter.spec.js
+++ b/tests/http-adapter.spec.js
@@ -121,7 +121,7 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
-        url: new global.URL(path1, global.location.origin)
+        url: expect.stringContaining(path1)
       }))
     })
 
@@ -138,7 +138,7 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
-        url: new global.URL(path1, global.location.origin)
+        url: expect.stringContaining(path1)
       }))
     })
 
@@ -154,7 +154,7 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
-        url: new global.URL(path1, global.location.origin)
+        url: expect.stringContaining(path1)
       }))
 
       await fetch1
@@ -164,7 +164,7 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(2)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({
-        url: new global.URL(path2, global.location.origin)
+        url: expect.stringContaining(path2)
       }))
 
       await fetch2
@@ -183,7 +183,7 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(1)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
-        url: new global.URL(path1, global.location.origin)
+        url: expect.stringContaining(path1)
       }))
 
       await fetch1
@@ -193,7 +193,7 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(2)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({
-        url: new global.URL(path2, global.location.origin)
+        url: expect.stringContaining(path2)
       }))
 
       await fetch2
@@ -208,10 +208,10 @@ describe('HTTP adapter', () => {
 
       expect(adapter._makeRequest).toHaveBeenCalledTimes(4)
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(3, expect.objectContaining({
-        url: new global.URL(path1, global.location.origin)
+        url: expect.stringContaining(path1)
       }))
       expect(adapter._makeRequest).toHaveBeenNthCalledWith(4, expect.objectContaining({
-        url: new global.URL(path2, global.location.origin)
+        url: expect.stringContaining(path2)
       }))
     })
   })

--- a/tests/model-proxy.spec.js
+++ b/tests/model-proxy.spec.js
@@ -142,11 +142,11 @@ describe('ModelProxy', function () {
     sinon.assert.calledOnce(spyB)
   })
 
-  it('isPending is true when the promise has not been resolved or rejected')
-  it('isResolved is true when the promise has been resolved')
-  it('isResolved is false when the promise has been rejected')
-  it('isRejected is true when the promise has been rejected')
-  it('isRejected is false when the promise has been resolved')
+  it('isPending is true when the promise has not been resolved or rejected', () => {})
+  it('isResolved is true when the promise has been resolved', () => {})
+  it('isResolved is false when the promise has been rejected', () => {})
+  it('isRejected is true when the promise has been rejected', () => {})
+  it('isRejected is false when the promise has been resolved', () => {})
 
   it('sets the content when the promise is resolved', function () {
     let model = new ModelProxy(new Model({something: 'nothing'}))

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,3 @@
+import nodeFetch from 'node-fetch'
+
+global.fetch = nodeFetch

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -465,7 +465,7 @@ describe('Store', function () {
       })
     })
 
-    it('makes request with a valid request body')
+    it('makes request with a valid request body', () => {})
   })
 
   describe('update', function () {
@@ -493,8 +493,8 @@ describe('Store', function () {
       })
     })
 
-    it('only PATCHes dirty attributes')
-    it('makes request with a valid request body')
+    it('only PATCHes dirty attributes', () => {})
+    it('makes request with a valid request body', () => {})
   })
 
   describe('destroy', function () {
@@ -514,12 +514,12 @@ describe('Store', function () {
     })
 
     // maybe this is wrong, maybe the store should simply not return deteled records?
-    it('removes a record from the store')
-    it('makes request with an empty request body')
+    it('removes a record from the store', () => {})
+    it('makes request with an empty request body', () => {})
   })
 
   describe('reload', function () {
-    it('fetches a single resource')
-    it('updates the resource with the response')
+    it('fetches a single resource', () => {})
+    it('updates the resource with the response', () => {})
   })
 })


### PR DESCRIPTION
The purpose of this PR is to migrate the http-adapter off of jQuery. jQuery over the years has lost a lot of popularity, increasing the risk of deprecation and support. Multiple libraries, such as jquery-cookie, have already been deprecated. We want to be able to use tools that are well supported incase issues arise. Most jQuery functionality is now natively supported by most browsers. We could use this opportunity to reduce our bundle side while moving strong into the future.

## HTTP Library Evaluation
There are multiple JavaScript HTTP libraries out there for consumption, but how do we pick the right one? The 3 most popular ways of doing this right now are using Axios, Request, or the Fetch API.

### Request
Easily the most popular, request gets over 14 Millions downloads a week. It has very little active development, meaning its either a) very stable, or b) not well supported. I will guess the first. Request is a very large library, coming in at ~180KB zipped. If you want promised based support, add another ~65KB. That's huge!

### Axios
As a lightweight (4.7KB) promise based http client, Axios has gained a lot of popularity. They have made a few releases recently and support instanced http clients as well as global configurations for items like 'headers'. It's a great choice for browser/node http clients and adds a little more opinionated structure for making/handling requests.

Though Axios is awesome, I do not feel it currently fits our use case. There is some functionality that we need to support that makes us feel like we are fighting Axios magic, explicitly our synchronous request mode for caveat cases. Right now I do not feel this is a good contender for us.

### Fetch
Our last option would be fetch, the successor to XHR in modern browsers. Since fetch is native, we do not need to import it as a dependency. This allows us to keep our bundle minimal and guarantee support of the API. It's very easy to use and understand, and allows a less opinionated structure for us to handle our http requests for our current requirements.

Fetch is not currently support in Internet Explorer. Luckily, github has provided its own polyfill library, whatwg-fetch. This polyfill is well supported with over 1.4 million users. We can use this until IE EOL 2025. 

I think this makes fetch the ideal choice for us moving forward and have implemented the following PR in fetch.

## Consumer Changes
This change will require consumers to change the way default headers are set in their app via $.ajax. This could be considered a breaking change and we should version appropriately. Some dependencies have been changed to make the package more bundle reduction friendly. These dependency changes can be changed, of course. Corresponding webapp changes will be discussed in another PR

This change will not be consumed by the groveco site until
 a) Babel 7 has been implemented
 b) corejs-3 is being consumed to gain support for URL. This will guarantee support in IE 11

I have tested these changes in a groveco site branch without $.ajax and with an implementation to pass along common headers. All functionality works as expected within the http-adapter.

Please see PR #62 for other comments and discussions

More specific error handling will come in a future PR to migrate away from generic Error() so the logs are more traceable 