### PR TITLE
Feature/upgrade jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  collectCoverage: true,
+  testMatch: ['**/*.spec.js'],
+  coverageDirectory: './coverage',
+  transform: {
+    '^.+\\.js$': require.resolve('babel-jest')
+  },
+  reporters: [
+    'default',
+    'jest-junit'
+  ],
+  testURL: 'http://localhost/'
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src --out-dir dist",
     "build:watch": "babel --watch src --out-dir dist",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",
-    "test": "jest ./tests",
+    "test": "jest",
     "lint": "eslint ./src/index.js"
   },
   "dependencies": {
@@ -19,6 +19,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
@@ -27,15 +28,9 @@
     "eslint-plugin-jest": "^19.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "jest": "^22.4.0",
-    "jest-junit": "^1.3.0",
+    "jest": "^24.9.0",
+    "jest-junit": "^10.0.0",
     "jsdoc": "^3.6.2",
     "sinon": "^1.17.2"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "coverageDirectory": "./coverage",
-    "testResultsProcessor": "jest-junit",
-    "testURL": "http://localhost/"
   }
 }

--- a/tests/collection-proxy.spec.js
+++ b/tests/collection-proxy.spec.js
@@ -156,11 +156,11 @@ describe('CollectionProxy', function () {
     sinon.assert.calledOnce(spyB)
   })
 
-  it('isPending is true when the promise has not been resolved or rejected')
-  it('isResolved is true when the promise has been resolved')
-  it('isResolved is false when the promise has been rejected')
-  it('isRejected is true when the promise has been rejected')
-  it('isRejected is false when the promise has been resolved')
+  it.todo('isPending is true when the promise has not been resolved or rejected')
+  it.todo('isResolved is true when the promise has been resolved')
+  it.todo('isResolved is false when the promise has been rejected')
+  it.todo('isRejected is true when the promise has been rejected')
+  it.todo('isRejected is false when the promise has been resolved')
 
   it('sets the content when the promise is resolved', function () {
     let collection = new CollectionProxy(new Collection([{something: 'nothing'}]))

--- a/tests/internal-model.spec.js
+++ b/tests/internal-model.spec.js
@@ -190,8 +190,8 @@ let userWithRelationships = {
 }
 
 describe('InternalModel', function () {
-  it('triggers a change event when a new relationship is added')
-  it('peeks a new related resource when a relationship is added')
+  it.todo('triggers a change event when a new relationship is added')
+  it.todo('peeks a new related resource when a relationship is added')
 
   describe('toJSON', function () {
     it('returns a hash of all attributes and computed properties', function () {
@@ -354,6 +354,6 @@ describe('InternalModel', function () {
       return expect(() => resource.getRelated('unregistered')).toThrow('Relation for "unregistered" is not defined on the model.')
     })
 
-    it('pends request until parent promise has resolved')
+    it.todo('pends request until parent promise has resolved')
   })
 })

--- a/tests/model-proxy.spec.js
+++ b/tests/model-proxy.spec.js
@@ -142,11 +142,11 @@ describe('ModelProxy', function () {
     sinon.assert.calledOnce(spyB)
   })
 
-  it('isPending is true when the promise has not been resolved or rejected')
-  it('isResolved is true when the promise has been resolved')
-  it('isResolved is false when the promise has been rejected')
-  it('isRejected is true when the promise has been rejected')
-  it('isRejected is false when the promise has been resolved')
+  it.todo('isPending is true when the promise has not been resolved or rejected')
+  it.todo('isResolved is true when the promise has been resolved')
+  it.todo('isResolved is false when the promise has been rejected')
+  it.todo('isRejected is true when the promise has been rejected')
+  it.todo('isRejected is false when the promise has been resolved')
 
   it('sets the content when the promise is resolved', function () {
     let model = new ModelProxy(new Model({something: 'nothing'}))

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -465,7 +465,7 @@ describe('Store', function () {
       })
     })
 
-    it('makes request with a valid request body')
+    it.todo('makes request with a valid request body')
   })
 
   describe('update', function () {
@@ -493,8 +493,8 @@ describe('Store', function () {
       })
     })
 
-    it('only PATCHes dirty attributes')
-    it('makes request with a valid request body')
+    it.todo('only PATCHes dirty attributes')
+    it.todo('makes request with a valid request body')
   })
 
   describe('destroy', function () {
@@ -514,12 +514,12 @@ describe('Store', function () {
     })
 
     // maybe this is wrong, maybe the store should simply not return deteled records?
-    it('removes a record from the store')
-    it('makes request with an empty request body')
+    it.todo('removes a record from the store')
+    it.todo('makes request with an empty request body')
   })
 
   describe('reload', function () {
-    it('fetches a single resource')
-    it('updates the resource with the response')
+    it.todo('fetches a single resource')
+    it.todo('updates the resource with the response')
   })
 })


### PR DESCRIPTION
The goal of this PR is to upgrade Jest from version 22 to version 24 to utilize newer methods available. This will help us stay up to date with changes, which has a variety of benefits.

From the [upgrade docs](https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly#typescript-support):

_Note that if you for whatever reason cannot upgrade to Babel 7, you can still use Jest 24 with babel@6 as long as you keep babel-jest at version 23._ 
