### PR TITLE
Feature/include src module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 .circleci/
 
-src/
 tests/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
   "module": "src/index.js",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "scripts": {
     "prepack": "NODE_ENV=development npm install && npm run build",
     "build": "babel src --out-dir dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@groveco/backbone.store",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "version": "0.3.3",
   "scripts": {
     "prepack": "NODE_ENV=development npm install && npm run build",


### PR DESCRIPTION
The goal of this PR is to allow an option to import backbone.store as raw source (no transpilation) into other grove apps. This should help reduce the bundle size in grove applications, as well as gain tree shaking abilities. Please see [HHR-127](https://groveco.atlassian.net/browse/HHR-127) for more details.

This is not likely a breaking change moving forward, but we likely should public a new feature  (0.4.0). Grove applications will need to be updated accordingly, which a draft PR will be worked on shortly to accomplish this goal.