### PR TITLE
[breaking] upgrade from babel 6 to babel 7 without plugins/corejs3 fo…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    "stage-0",
-    "env"
-  ],
-  "plugins": [
-    "transform-runtime"
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current'
+        }
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
     "underscore": "^1.9.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-jest": "^23.6.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-stage-0": "^6.24.1",
+    "@babel/cli": "^7.10.1",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "babel-jest": "^24.9.0",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^7.0.1",
     "eslint-plugin-jest": "^19.0.1",


### PR DESCRIPTION
This PR is to upgrade from Babel 6 to Babel 7 to share similar configuration other grove apps and to remove deprecated modules and transformers.

This Babel 7 upgrade is ONLY here to support transformation of ES6 import/exports for the jest resolver with minimal configuration. This PR is contingent on #78 and should not even be considered for merging until #78 is addressed.

The babel.config.js does not have any of the runtime transformers or the stage-0 presets. Though I do not believe we use any of the stage-0 features in the production bundle, there are items that will NOT be transformed since node is the runtime target.

If this PR is merged before #78  is handled according and a patch release is made, the webapp WILL break.