### PR TITLE
Search collection meta

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -96,7 +96,7 @@ class Store {
     if (_.isArray(data)) {
       const result = new Collection(data.map(model => this._pushInternalModel(model)));
       if (meta) {
-        result.meta = meta;
+        result.meta = this._parser._parseWithNames(meta);
       }
       return result;
     }

--- a/src/store.js
+++ b/src/store.js
@@ -83,7 +83,7 @@ class Store {
    * @returns {internal-model | Collection}
    */
   push (resource) {
-    let {data, included} = resource
+    let {data, included, meta} = resource
 
     if (!resource.hasOwnProperty('data')) {
       throw new Error('Expected the resource pushed to include a top level property `data`')
@@ -94,7 +94,11 @@ class Store {
     }
 
     if (_.isArray(data)) {
-      return new Collection(data.map(model => this._pushInternalModel(model)))
+      const result = new Collection(data.map(model => this._pushInternalModel(model)));
+      if (meta) {
+        result.meta = meta;
+      }
+      return result;
     }
 
     if (data == null) {

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -72,6 +72,33 @@ describe('Store', function () {
       sinon.assert.calledTwice(spy)
       expect(user.get('name')).toEqual('bar')
     })
+
+    it('adds metadata to the collection if it exists', function () {
+      const store = createStore()
+      const userCollection = store.push({
+        data: [
+          {
+            id: 2,
+            type: 'user',
+            attributes: {
+              name: 'foo'
+            }
+          },
+          {
+            id: 4,
+            type: 'user',
+            attributes: {
+              name: 'bar'
+            }
+          }
+        ],
+        meta: {
+          'search-string': 'foobar',
+        }
+      })
+      expect(userCollection.at(0).get('name')).toEqual('foo')
+      expect(userCollection.meta.searchString).toEqual('foobar')
+    })
   })
 
   describe('get', function () {


### PR DESCRIPTION
## Description
Within the JSON api spec, "meta" is an optional attribute that can be returned, containing a dictionary-like object. Backbone.store should support metadata for collections, such as search. Caching or not caching metadata on model objects can be a problem, so "meta" is still not supported on those requests.

There is an old, closed PR which implemented a similar objective: https://github.com/groveco/backbone.store/pull/43

## Testing
To test these changes, I did the following for my local grove setup:
1. Startup the containers
2. Exec into the containers. `docker-compose exec node /bin/bash`. You may need to disable the silly `git` alias in the `.bashrc`
3. Git clone this repo _inside the container_
4. Link the cloned repo into the dependencies. You can follow the steps in this repo's readme. It's essentially: At the top of this git repo (backbone.store) enter `npm link`. At the top of the other project's directory (e.g. grove), `npm link @groveco/backbone.store`
5. Checkout this branch in the backbone.store repo in the container.
6. Restart npm for grove. `ps aux`. `kill <PID>` of the node process. `npm start`
7. Perform a call to a json api endpoint which returns multiple results and metadata. For example, `store.fetch('product', null, { link: '/api/product/blessedsearch', query: { q: 'meyers' } })`. Note: if using the grove repo you may need to make adjustments to the store.js initializer. It needs `JqueryHttpAdapter` as the import.
8. See that the "meta" attribute correctly propagates to the application.

## Risks

### Versioning problem
Grove-mama is not yet ready for 0.5.0 changes, so this will need to be a minor release 0.4.1 as well as 0.5.1. Git acrobatics!
