### PR TITLE
Bump patch version to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@groveco/backbone.store",
   "main": "src/index.js",
   "module": "src/index.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "prepack": "NODE_ENV=development npm install",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",


### PR DESCRIPTION
With the update to meta, we should also bump the most recent version so both 0.5.1 and 0.4.1 exist.