### PR TITLE
Bump to version 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@groveco/backbone.store",
   "main": "src/index.js",
   "module": "src/index.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "prepack": "NODE_ENV=development npm install",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",


### PR DESCRIPTION
## Description
I had some troubles with publishing correctly, so this a replica of https://github.com/groveco/backbone.store/pull/82. 

`npm version` followed by `npm publish` doesn't work for some reason; I believe we don't have those `preversion`, `version`, and `postversion` scripts specified in our package.json. This causes the checkout of the tag to fail within CircleCI. 

We **DO**, however, have hooks set up within CircleCI to pick up the latest tag and publish the version. So steps I took to publish it via CircleCI.
1. Checkout new branch.
2. Manually modify the version in `package.json`
3. Git add, commit, and push.
4. Add an annotated git tag following the correct format: `git tag -a v0.5.1 -m "Version 0.5.1"`
5. Push the tag to remote. `git push origin --tags`
6. Follow CircleCI and make sure it publishes successfully. Verify the [latest version](https://www.npmjs.com/package/@groveco/backbone.store).