### PR TITLE
bump jquery to 3.6.0 to avoid security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "backbone": "^1.3.3",
     "clone": "^2.1.0",
-    "jquery": "^2.2.4",
+    "jquery": "3.6.0",
     "underscore": "^1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
bumping and pinning jquery to 3.6.0 

Please checkout https://github.com/groveco/backbone.store/pull/69 from dependabot for more info