### PR TITLE
Forward port jquery 3.6.0 upgrade to master & bump to v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "backbone": "^1.3.3",
     "clone": "^2.1.0",
-    "jquery": "^3.5.0",
+    "jquery": "^3.6.0",
     "underscore": "^1.9.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@groveco/backbone.store",
   "main": "src/index.js",
   "module": "src/index.js",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "prepack": "NODE_ENV=development npm install",
     "build:docs": "jsdoc --readme README.md src/* -d ./docs",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "backbone": "^1.3.3",
     "clone": "^2.1.0",
-    "jquery": "^2.2.4",
+    "jquery": "^3.5.0",
     "underscore": "^1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Opening a PR to forward port the jquery upgrade released in v0.4.2 to master. Patch version has been bumped.